### PR TITLE
Improve payment verification and access tracking

### DIFF
--- a/app/api/payments/initialize/route.ts
+++ b/app/api/payments/initialize/route.ts
@@ -6,14 +6,58 @@ export const runtime = "nodejs"
 
 const PAYSTACK_SECRET_KEY = process.env.PAYSTACK_SECRET_KEY || "sk_test_your_secret_key_here"
 
+function sanitizeMetadataInput(metadata: unknown): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object") {
+    return {}
+  }
+
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(metadata as Record<string, unknown>)) {
+    if (value === undefined || value === null) {
+      continue
+    }
+
+    sanitized[key] = typeof value === "string" ? sanitizeInput(value) : value
+  }
+
+  return sanitized
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { email, amount, metadata, studentId, paymentType } = body
+    const email = typeof body.email === "string" ? body.email : ""
+    const rawAmount = Number(body.amount)
 
-    if (!email || !amount) {
-      return NextResponse.json({ status: false, message: "Email and amount are required" }, { status: 400 })
+    if (!email || Number.isNaN(rawAmount) || rawAmount <= 0) {
+      return NextResponse.json(
+        { status: false, message: "Valid email and amount are required" },
+        { status: 400 },
+      )
     }
+
+    const amountInKobo = Math.round(rawAmount)
+    const amountInNaira = amountInKobo / 100
+    const sanitizedEmail = sanitizeInput(email)
+    const sanitizedMetadata = sanitizeMetadataInput(body.metadata)
+    const sanitizedStudentId =
+      typeof body.studentId === "string" || typeof body.studentId === "number"
+        ? sanitizeInput(String(body.studentId))
+        : null
+    const normalizedPaymentType =
+      typeof body.paymentType === "string" && body.paymentType.trim().length > 0
+        ? sanitizeInput(body.paymentType)
+        : typeof sanitizedMetadata.payment_type === "string"
+          ? sanitizeInput(String(sanitizedMetadata.payment_type))
+          : "general"
+
+    if (sanitizedStudentId) {
+      sanitizedMetadata.student_id = sanitizedStudentId
+      sanitizedMetadata.studentId = sanitizedStudentId
+    }
+
+    sanitizedMetadata.payment_type = normalizedPaymentType
 
     const response = await fetch("https://api.paystack.co/transaction/initialize", {
       method: "POST",
@@ -22,9 +66,9 @@ export async function POST(request: NextRequest) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        email,
-        amount,
-        metadata,
+        email: sanitizedEmail,
+        amount: amountInKobo,
+        metadata: sanitizedMetadata,
         callback_url: `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/payment/callback`,
       }),
     })
@@ -35,13 +79,13 @@ export async function POST(request: NextRequest) {
       try {
         await recordPaymentInitialization({
           reference: data.data?.reference ?? data.data?.access_code ?? `paystack_${Date.now()}`,
-          amount: Number(amount),
-          studentId: studentId ? String(studentId) : null,
-          paymentType: paymentType ? sanitizeInput(paymentType) : "general",
-          email: sanitizeInput(email),
+          amount: amountInNaira,
+          studentId: sanitizedStudentId,
+          paymentType: normalizedPaymentType,
+          email: sanitizedEmail,
           status: "pending",
           paystackReference: data.data?.reference ?? null,
-          metadata: metadata ?? undefined,
+          metadata: sanitizedMetadata,
         })
       } catch (dbError) {
         console.error("Failed to record payment initialization:", dbError)

--- a/app/api/payments/verify/route.ts
+++ b/app/api/payments/verify/route.ts
@@ -1,8 +1,49 @@
 import { type NextRequest, NextResponse } from "next/server"
 
+import {
+  createOrUpdateReceipt,
+  findPaymentByReference,
+  recordPaymentInitialization,
+  updatePaymentRecord,
+} from "@/lib/database"
+import { sanitizeInput } from "@/lib/security"
+
 export const runtime = "nodejs"
 
 const PAYSTACK_SECRET_KEY = process.env.PAYSTACK_SECRET_KEY || "sk_test_your_secret_key_here"
+
+function sanitizeMetadataInput(metadata: unknown): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object") {
+    return {}
+  }
+
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(metadata as Record<string, unknown>)) {
+    if (value === undefined || value === null) {
+      continue
+    }
+
+    sanitized[key] = typeof value === "string" ? sanitizeInput(value) : value
+  }
+
+  return sanitized
+}
+
+function resolveStudentName(metadata: Record<string, unknown>): string {
+  const fromSnake = metadata.student_name
+  const fromCamel = metadata.studentName
+
+  if (typeof fromSnake === "string" && fromSnake.trim().length > 0) {
+    return fromSnake
+  }
+
+  if (typeof fromCamel === "string" && fromCamel.trim().length > 0) {
+    return sanitizeInput(fromCamel)
+  }
+
+  return "Student"
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,6 +53,8 @@ export async function GET(request: NextRequest) {
     if (!reference) {
       return NextResponse.json({ status: false, message: "Payment reference is required" }, { status: 400 })
     }
+
+    const sanitizedReference = sanitizeInput(reference)
 
     const response = await fetch(`https://api.paystack.co/transaction/verify/${reference}`, {
       method: "GET",
@@ -24,20 +67,127 @@ export async function GET(request: NextRequest) {
     const data = await response.json()
 
     if (data.status && data.data.status === "success") {
+      const gatewayData = data.data
+      const amountInNaira = Number(gatewayData.amount) / 100
+      const paystackReference =
+        typeof gatewayData.reference === "string" && gatewayData.reference.trim().length > 0
+          ? sanitizeInput(gatewayData.reference)
+          : sanitizedReference
+      const metadata = sanitizeMetadataInput(gatewayData.metadata)
+      const studentIdRaw =
+        typeof metadata.student_id === "string"
+          ? metadata.student_id
+          : typeof metadata.studentId === "string"
+            ? sanitizeInput(String(metadata.studentId))
+            : null
+      const studentId = studentIdRaw && studentIdRaw.trim().length > 0 ? sanitizeInput(studentIdRaw) : null
+      const paymentType =
+        typeof metadata.payment_type === "string" && metadata.payment_type.trim().length > 0
+          ? sanitizeInput(metadata.payment_type)
+          : "general"
+      const nowIso = new Date().toISOString()
+      const channel =
+        typeof gatewayData.channel === "string" && gatewayData.channel.trim().length > 0
+          ? sanitizeInput(gatewayData.channel)
+          : "online"
+
+      if (studentId) {
+        metadata.student_id = studentId
+        metadata.studentId = studentId
+      } else {
+        delete metadata.student_id
+        delete metadata.studentId
+      }
+      metadata.payment_type = paymentType
+      metadata.payment_channel = channel
+      metadata.accessGranted = true
+      metadata.accessGrantedAt = nowIso
+      metadata.verifiedAt = nowIso
+      metadata.lastPaystackReference = paystackReference
+
+      const customerEmail =
+        gatewayData.customer && typeof gatewayData.customer.email === "string"
+          ? sanitizeInput(gatewayData.customer.email)
+          : ""
+
+      let paymentRecord = await findPaymentByReference(paystackReference)
+
+      if (!paymentRecord && paystackReference !== sanitizedReference) {
+        paymentRecord = await findPaymentByReference(sanitizedReference)
+      }
+
+      if (!paymentRecord) {
+        paymentRecord = await recordPaymentInitialization({
+          reference: paystackReference,
+          amount: amountInNaira,
+          studentId,
+          paymentType,
+          email: customerEmail || "payments@vea-portal.local",
+          status: "completed",
+          paystackReference,
+          metadata,
+        })
+      } else {
+        const updated = await updatePaymentRecord(paymentRecord.id, {
+          status: "completed",
+          amount: amountInNaira,
+          studentId: studentId ?? paymentRecord.studentId ?? null,
+          paymentType,
+          email: customerEmail || paymentRecord.email,
+          reference: paystackReference,
+          paystackReference,
+          metadata,
+        })
+
+        if (updated) {
+          paymentRecord = updated
+        }
+      }
+
+      const studentName = resolveStudentName(metadata)
+      const receipt = await createOrUpdateReceipt({
+        paymentId: paymentRecord.id,
+        studentName,
+        amount: amountInNaira,
+        reference: paystackReference,
+        issuedBy: "Automated Verification",
+        metadata: {
+          paymentType,
+          term: typeof metadata.term === "string" ? metadata.term : undefined,
+          session: typeof metadata.session === "string" ? metadata.session : undefined,
+          verifiedAt: nowIso,
+          channel,
+        },
+      })
+
       return NextResponse.json({
         status: true,
         message: "Payment verified successfully",
         data: {
-          reference: data.data.reference,
-          amount: data.data.amount / 100, // Convert from kobo to naira
-          customer: data.data.customer,
-          metadata: data.data.metadata,
-          paid_at: data.data.paid_at,
+          reference: paystackReference,
+          amount: amountInNaira,
+          customer: gatewayData.customer,
+          metadata,
+          paid_at: gatewayData.paid_at,
+          payment: paymentRecord,
+          receipt,
         },
       })
-    } else {
-      return NextResponse.json({ status: false, message: "Payment verification failed" }, { status: 400 })
     }
+
+    try {
+      const existing = await findPaymentByReference(sanitizedReference)
+      if (existing) {
+        await updatePaymentRecord(existing.id, {
+          status: "failed",
+          metadata: { lastVerificationAttempt: new Date().toISOString() },
+        })
+      }
+    } catch (updateError) {
+      console.error("Failed to update payment status after verification failure:", updateError)
+    }
+
+    return NextResponse.json({ status: false, message: "Payment verification failed" }, { status: 400 })
   } catch (error) {
     console.error("Payment verification error:", error)
     return NextResponse.json({ status: false, message: "Internal server error" }, { status: 500 })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -951,6 +951,7 @@ function ParentDashboard({ user }: { user: User }) {
         onClose={() => setShowPaymentModal(false)}
         onPaymentSuccess={handlePaymentSuccess}
         studentName={studentData.name}
+        studentId={studentData.id}
         amount={50000}
       />
     </div>

--- a/components/admin/payment-management.tsx
+++ b/components/admin/payment-management.tsx
@@ -127,11 +127,15 @@ export function PaymentManagement() {
         const response = await fetch("/api/payments/records", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            id: paymentId,
-            status: hasAccess ? "completed" : "pending",
-            accessGranted: hasAccess,
-          }),
+        body: JSON.stringify({
+          id: paymentId,
+          status: hasAccess ? "completed" : "pending",
+          accessGranted: hasAccess,
+          metadata: {
+            accessUpdatedBy: "admin",
+            accessUpdateReason: hasAccess ? "manual-grant" : "manual-revoke",
+          },
+        }),
         })
 
         if (!response.ok) {

--- a/components/payment-modal.tsx
+++ b/components/payment-modal.tsx
@@ -15,10 +15,18 @@ interface PaymentModalProps {
   onClose: () => void
   onPaymentSuccess: () => void
   studentName: string
+  studentId: string
   amount: number
 }
 
-export function PaymentModal({ isOpen, onClose, onPaymentSuccess, studentName, amount }: PaymentModalProps) {
+export function PaymentModal({
+  isOpen,
+  onClose,
+  onPaymentSuccess,
+  studentName,
+  studentId,
+  amount,
+}: PaymentModalProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [paymentForm, setPaymentForm] = useState({
     email: "",
@@ -40,9 +48,14 @@ export function PaymentModal({ isOpen, onClose, onPaymentSuccess, studentName, a
         },
         body: JSON.stringify({
           email: paymentForm.email,
-          amount: amount * 100, // Convert to kobo
+          amount: amount * 100, // Convert to kobo for Paystack
+          studentId,
+          paymentType: "school_fees",
           metadata: {
             student_name: studentName,
+            studentId,
+            student_id: studentId,
+            payment_type: "school_fees",
             term: paymentForm.term,
             session: paymentForm.session,
             phone: paymentForm.phone,

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1454,6 +1454,29 @@ export async function recordPaymentInitialization(
   return deepClone(updated)
 }
 
+export async function findPaymentByReference(reference: string): Promise<PaymentInitializationRecord | null> {
+  if (!reference || reference.trim().length === 0) {
+    return null
+  }
+
+  const payments = ensureCollection<PaymentInitializationRecord>(STORAGE_KEYS.PAYMENTS, defaultEmptyCollection)
+  const normalized = reference.trim().toLowerCase()
+
+  const match = payments.find((payment) => {
+    if (payment.reference && payment.reference.trim().toLowerCase() === normalized) {
+      return true
+    }
+
+    if (payment.paystackReference && payment.paystackReference.trim().toLowerCase() === normalized) {
+      return true
+    }
+
+    return false
+  })
+
+  return match ? deepClone(match) : null
+}
+
 export async function listPaymentInitializations(): Promise<PaymentInitializationRecord[]> {
   const payments = ensureCollection<PaymentInitializationRecord>(STORAGE_KEYS.PAYMENTS, defaultEmptyCollection)
   return deepClone(payments)


### PR DESCRIPTION
## Summary
- sanitize and normalize Paystack initialization input before persisting and ensure amounts are stored in naira
- connect payment verification to the data layer to grant access, log receipts, and handle failure states
- pass student identifiers through the UI and track manual access overrides for administrators

## Testing
- pnpm lint *(fails: pre-existing lint violations across the repository)*
- pnpm type-check *(fails: pre-existing type errors across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cec330907883278a077bd2e1d24338