### PR TITLE
Integrate database-backed user management

### DIFF
--- a/components/admin/user-management.tsx
+++ b/components/admin/user-management.tsx
@@ -53,13 +53,13 @@ interface User {
 }
 
 const ROLE_OPTIONS: { value: UserRole; label: string; api: string }[] = [
-  { value: "super-admin", label: "Super Admin", api: "Super Admin" },
-  { value: "admin", label: "Admin", api: "Admin" },
-  { value: "teacher", label: "Teacher", api: "Teacher" },
-  { value: "student", label: "Student", api: "Student" },
-  { value: "parent", label: "Parent", api: "Parent" },
-  { value: "librarian", label: "Librarian", api: "Librarian" },
-  { value: "accountant", label: "Accountant", api: "Accountant" },
+  { value: "super-admin", label: "Super Admin", api: "super_admin" },
+  { value: "admin", label: "Admin", api: "admin" },
+  { value: "teacher", label: "Teacher", api: "teacher" },
+  { value: "student", label: "Student", api: "student" },
+  { value: "parent", label: "Parent", api: "parent" },
+  { value: "librarian", label: "Librarian", api: "librarian" },
+  { value: "accountant", label: "Accountant", api: "accountant" },
 ]
 
 const STATUS_BADGE: Record<UserStatus, string> = {
@@ -79,7 +79,7 @@ const ROLE_BADGE: Record<UserRole, string> = {
 }
 
 function normalizeRole(role: string): UserRole {
-  const normalized = role.toLowerCase().replace(" ", "-")
+  const normalized = role.toLowerCase().replace(/[_\s]+/g, "-")
   if (
     normalized === "super-admin" ||
     normalized === "admin" ||

--- a/scripts/database-schema.sql
+++ b/scripts/database-schema.sql
@@ -17,9 +17,14 @@ CREATE TABLE IF NOT EXISTS users (
     'librarian',
     'accountant'
   ) NOT NULL DEFAULT 'student',
-  class VARCHAR(255) NULL,
+  status ENUM('active', 'inactive', 'suspended') NOT NULL DEFAULT 'active',
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  class_id VARCHAR(255) NULL,
   subjects JSON NULL,
   student_ids JSON NULL,
+  metadata JSON NULL,
+  profile_image TEXT NULL,
+  last_login DATETIME NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- add MySQL-backed implementations for user CRUD helpers with safe local fallback
- normalize role values in the admin user management UI and API so they align with database expectations
- extend the users table schema with status, activation, metadata, and audit fields for cPanel deployment

## Testing
- pnpm lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cec76a877c8327a5ae261752c0ce28