### PR TITLE
Implement backend-powered noticeboard and analytics dashboards

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,69 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import {
+  getAcademicAnalytics,
+  listAnalyticsReports,
+  saveAnalyticsReport,
+  type CreateAnalyticsReportPayload,
+  type AnalyticsReportRecord,
+} from "@/lib/database"
+import { logger } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const term = searchParams.get("term") ?? "current"
+    const classFilter = searchParams.get("class") ?? searchParams.get("className") ?? "all"
+    const includeReports = searchParams.get("includeReports") === "true"
+
+    const analytics = await getAcademicAnalytics(term, classFilter)
+    let reports: Array<{
+      id: string
+      term: string
+      className: string
+      generatedAt: string
+      payload: Record<string, unknown>
+    }> | undefined
+
+    if (includeReports) {
+      const storedReports = await listAnalyticsReports()
+      reports = storedReports.map((report: AnalyticsReportRecord) => ({
+        id: report.id,
+        term: report.term,
+        className: report.className,
+        generatedAt: report.generatedAt,
+        payload: report.payload,
+      }))
+    }
+
+    return NextResponse.json({ analytics, reports })
+  } catch (error) {
+    logger.error("Failed to load academic analytics", { error })
+    return NextResponse.json({ error: "Failed to load analytics" }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const reportPayload = body?.payload ?? body?.data
+    const payload: CreateAnalyticsReportPayload = {
+      term: String(body?.term ?? "all"),
+      className: String(body?.class ?? body?.className ?? "all"),
+      generatedAt: typeof body?.generatedAt === "string" ? body.generatedAt : new Date().toISOString(),
+      payload:
+        reportPayload && typeof reportPayload === "object"
+          ? (reportPayload as Record<string, unknown>)
+          : {},
+    }
+
+    const report = await saveAnalyticsReport(payload)
+    return NextResponse.json({ report })
+  } catch (error) {
+    logger.error("Failed to save analytics report", { error })
+    return NextResponse.json({ error: "Failed to save analytics report" }, { status: 500 })
+  }
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { verifyPassword, generateToken, sanitizeInput } from "@/lib/security"
 import { getUserByEmail } from "@/lib/database"
+import { logger } from "@/lib/logger"
 
 export async function POST(request: NextRequest) {
   try {
@@ -35,7 +36,8 @@ export async function POST(request: NextRequest) {
     })
 
     // Return user data without password
-    const { passwordHash, ...userWithoutPassword } = user
+    const { passwordHash: _passwordHash, ...userWithoutPassword } = user
+    void _passwordHash
 
     return NextResponse.json({
       user: userWithoutPassword,
@@ -43,7 +45,7 @@ export async function POST(request: NextRequest) {
       message: "Login successful",
     })
   } catch (error) {
-    console.error("Login error:", error)
+    logger.error("Login error", { error })
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,68 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { auth, type UserRole } from "@/lib/auth"
+import { sanitizeInput, validateEmail, validatePassword } from "@/lib/security"
+import { logger } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+const ROLE_MAP: Record<string, UserRole> = {
+  admin: "admin",
+  "super-admin": "super_admin",
+  super_admin: "super_admin",
+  teacher: "teacher",
+  student: "student",
+  parent: "parent",
+  librarian: "librarian",
+  accountant: "accountant",
+}
+
+function normalizeRole(roleInput: string): UserRole {
+  const mapped = ROLE_MAP[roleInput.toLowerCase()]
+  return mapped ?? "student"
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const name = sanitizeInput(String(body?.name ?? "")).trim()
+    const email = sanitizeInput(String(body?.email ?? "")).trim().toLowerCase()
+    const password = String(body?.password ?? "")
+    const roleInput = String(body?.role ?? "student")
+    const resolvedRole = normalizeRole(roleInput)
+
+    if (!name || !email || !password) {
+      return NextResponse.json({ error: "Name, email and password are required" }, { status: 400 })
+    }
+
+    if (!validateEmail(email)) {
+      return NextResponse.json({ error: "Please provide a valid email address" }, { status: 400 })
+    }
+
+    const passwordValidation = validatePassword(password)
+    if (!passwordValidation.isValid) {
+      return NextResponse.json({ error: passwordValidation.message }, { status: 400 })
+    }
+
+    const user = await auth.register({
+      name,
+      email,
+      password,
+      role: resolvedRole,
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: "Unable to register user" }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      user,
+      message: "Registration successful",
+    })
+  } catch (error) {
+    logger.error("Registration error", { error })
+    const message = error instanceof Error ? error.message : "Internal server error"
+    const status = message === "User already exists" ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/monitoring/route.ts
+++ b/app/api/monitoring/route.ts
@@ -1,0 +1,134 @@
+import os from "os"
+import { statfs } from "node:fs/promises"
+
+import { NextResponse } from "next/server"
+
+import { getSystemUsageSnapshot, measureDatabaseLatency } from "@/lib/database"
+import { logger } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+function calculateMemoryUsage(): number {
+  const total = os.totalmem()
+  const free = os.freemem()
+  if (total === 0) {
+    return 0
+  }
+
+  const used = total - free
+  return Number(((used / total) * 100).toFixed(1))
+}
+
+function calculateServerLoad(): number {
+  const [load] = os.loadavg()
+  const cpuCount = os.cpus().length || 1
+  return Number(((load / cpuCount) * 100).toFixed(1))
+}
+
+function formatUptime(uptimeInSeconds: number): string {
+  const hours = Math.floor(uptimeInSeconds / 3600)
+  const minutes = Math.floor((uptimeInSeconds % 3600) / 60)
+  const seconds = Math.floor(uptimeInSeconds % 60)
+  return `${hours}h ${minutes}m ${seconds}s`
+}
+
+function evaluateStatus(load: number, memoryUsage: number): "healthy" | "warning" | "critical" {
+  if (load > 85 || memoryUsage > 90) {
+    return "critical"
+  }
+
+  if (load > 70 || memoryUsage > 80) {
+    return "warning"
+  }
+
+  return "healthy"
+}
+
+async function calculateDiskUsage(): Promise<number> {
+  try {
+    const stats = await statfs(process.cwd())
+    const blockSize = Number(stats.bsize ?? stats.frsize ?? 0)
+    const totalBlocks = Number(stats.blocks ?? 0)
+    const freeBlocks = Number(stats.bfree ?? 0)
+
+    if (blockSize === 0 || totalBlocks === 0) {
+      return 0
+    }
+
+    const total = blockSize * totalBlocks
+    const free = blockSize * freeBlocks
+    const used = Math.max(total - free, 0)
+
+    return Number(((used / total) * 100).toFixed(1))
+  } catch (error) {
+    logger.warn("Unable to read disk usage statistics", { error })
+    return 0
+  }
+}
+
+function formatLastBackup(lastBackupAt: string | null): string {
+  if (!lastBackupAt) {
+    return "No backups recorded"
+  }
+
+  const backupDate = new Date(lastBackupAt)
+  if (Number.isNaN(backupDate.getTime())) {
+    return "Unknown"
+  }
+
+  const diffMs = Date.now() - backupDate.getTime()
+  if (diffMs <= 0) {
+    return "Just now"
+  }
+
+  const hours = Math.floor(diffMs / 3_600_000)
+  const minutes = Math.floor((diffMs % 3_600_000) / 60_000)
+
+  if (hours === 0 && minutes === 0) {
+    return "Just now"
+  }
+
+  if (hours === 0) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"} ago`
+  }
+
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? "" : "s"} ${minutes} minute${minutes === 1 ? "" : "s"} ago`
+  }
+
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? "" : "s"} ago`
+}
+
+export async function GET() {
+  try {
+    const [snapshot, diskUsage, latency] = await Promise.all([
+      getSystemUsageSnapshot(),
+      calculateDiskUsage(),
+      measureDatabaseLatency(),
+    ])
+
+    const uptime = formatUptime(process.uptime())
+    const memoryUsage = calculateMemoryUsage()
+    const serverLoad = calculateServerLoad()
+    const networkLatency = latency ?? 0
+
+    const metrics = {
+      uptime,
+      activeUsers: snapshot.activeUsers,
+      databaseConnections: snapshot.databaseConnections,
+      serverLoad,
+      memoryUsage,
+      diskUsage,
+      networkLatency,
+      lastBackup: formatLastBackup(snapshot.lastBackupAt),
+      systemStatus: evaluateStatus(serverLoad, memoryUsage),
+      timestamp: new Date().toISOString(),
+    }
+
+    return NextResponse.json({ metrics })
+  } catch (error) {
+    logger.error("Failed to gather monitoring metrics", { error })
+    return NextResponse.json({ error: "Failed to gather monitoring metrics" }, { status: 500 })
+  }
+}

--- a/app/api/noticeboard/[id]/route.ts
+++ b/app/api/noticeboard/[id]/route.ts
@@ -1,0 +1,94 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { deleteNoticeRecord, updateNoticeRecord } from "@/lib/database"
+import { logger } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const body = await request.json()
+    const id = params.id
+
+    if (!id) {
+      return NextResponse.json({ error: "Notice ID is required" }, { status: 400 })
+    }
+
+    const updates: Record<string, unknown> = {}
+
+    if (typeof body?.title === "string") {
+      updates.title = body.title
+    }
+
+    if (typeof body?.content === "string") {
+      updates.content = body.content
+    }
+
+    if (typeof body?.category === "string") {
+      updates.category = body.category
+    }
+
+    if (Array.isArray(body?.targetAudience)) {
+      updates.targetAudience = body.targetAudience
+    }
+
+    if (typeof body?.authorName === "string") {
+      updates.authorName = body.authorName
+    }
+
+    if (typeof body?.authorRole === "string") {
+      updates.authorRole = body.authorRole
+    }
+
+    if (typeof body?.isPinned === "boolean") {
+      updates.isPinned = body.isPinned
+    }
+
+    const notice = await updateNoticeRecord(id, updates)
+    if (!notice) {
+      return NextResponse.json({ error: "Notice not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({
+      notice: {
+        id: notice.id,
+        title: notice.title,
+        content: notice.content,
+        category: notice.category,
+        targetAudience: notice.targetAudience,
+        author: notice.authorName,
+        authorRole: notice.authorRole,
+        date: notice.createdAt,
+        isPinned: notice.isPinned,
+      },
+    })
+  } catch (error) {
+    logger.error("Failed to update notice", { error })
+    return NextResponse.json({ error: "Failed to update notice" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const id = params.id
+    if (!id) {
+      return NextResponse.json({ error: "Notice ID is required" }, { status: 400 })
+    }
+
+    const deleted = await deleteNoticeRecord(id)
+    if (!deleted) {
+      return NextResponse.json({ error: "Notice not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error("Failed to delete notice", { error })
+    return NextResponse.json({ error: "Failed to delete notice" }, { status: 500 })
+  }
+}

--- a/app/api/noticeboard/route.ts
+++ b/app/api/noticeboard/route.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import {
+  createNoticeRecord,
+  getNoticeRecords,
+  type CreateNoticePayload,
+  type NoticeRecord,
+} from "@/lib/database"
+import { logger } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+function mapNotice(record: NoticeRecord) {
+  return {
+    id: record.id,
+    title: record.title,
+    content: record.content,
+    category: record.category,
+    targetAudience: record.targetAudience,
+    author: record.authorName,
+    authorRole: record.authorRole,
+    date: record.createdAt,
+    isPinned: record.isPinned,
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const audience = searchParams.get("audience") ?? undefined
+    const pinned = searchParams.get("pinned")
+
+    const notices = await getNoticeRecords({
+      audience: audience ?? undefined,
+      onlyPinned: pinned === "true",
+    })
+
+    return NextResponse.json({ notices: notices.map(mapNotice) })
+  } catch (error) {
+    logger.error("Failed to load notices", { error })
+    return NextResponse.json({ error: "Failed to load notices" }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const payload: CreateNoticePayload = {
+      title: String(body?.title ?? "").trim(),
+      content: String(body?.content ?? "").trim(),
+      category: body?.category ?? "general",
+      targetAudience: Array.isArray(body?.targetAudience) ? body.targetAudience : [],
+      authorName: String(body?.authorName ?? "System"),
+      authorRole: String(body?.authorRole ?? "admin"),
+      isPinned: Boolean(body?.isPinned ?? false),
+    }
+
+    if (!payload.title || !payload.content || payload.targetAudience.length === 0) {
+      return NextResponse.json(
+        { error: "Title, content and at least one target audience are required" },
+        { status: 400 },
+      )
+    }
+
+    const notice = await createNoticeRecord(payload)
+    return NextResponse.json({ notice: mapNotice(notice) }, { status: 201 })
+  } catch (error) {
+    logger.error("Failed to create notice", { error })
+    return NextResponse.json({ error: "Failed to create notice" }, { status: 500 })
+  }
+}

--- a/app/api/timetable/route.ts
+++ b/app/api/timetable/route.ts
@@ -1,16 +1,105 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { dbManager } from "@/lib/database-manager"
+
+import {
+  createTimetableSlot,
+  deleteTimetableSlot,
+  getTimetableSlots,
+  updateTimetableSlot,
+} from "@/lib/database"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
+
+interface TimetableSlotResponse {
+  id: string
+  day: string
+  time: string
+  subject: string
+  teacher: string
+  location?: string | null
+  className: string
+}
+
+function to24Hour(time: string): string {
+  const trimmed = time.trim()
+  const match = trimmed.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)?$/i)
+
+  if (!match) {
+    return trimmed
+  }
+
+  let hour = Number(match[1])
+  const minute = match[2]
+  const meridiem = match[3]?.toUpperCase()
+
+  if (meridiem === "PM" && hour !== 12) {
+    hour += 12
+  }
+
+  if (meridiem === "AM" && hour === 12) {
+    hour = 0
+  }
+
+  return `${hour.toString().padStart(2, "0")}:${minute}`
+}
+
+function to12Hour(time: string): string {
+  const [hourPart, minutePart = "00"] = time.split(":")
+  let hour = Number(hourPart)
+  const minute = minutePart.padStart(2, "0")
+  const meridiem = hour >= 12 ? "PM" : "AM"
+  hour = hour % 12 || 12
+  return `${hour}:${minute} ${meridiem}`
+}
+
+function parseTimeRange(range: string): { start: string; end: string } {
+  if (typeof range !== "string" || range.trim().length === 0) {
+    return { start: "08:00", end: "09:00" }
+  }
+
+  const [rawStart, rawEnd] = range.split("-").map((value) => value.trim())
+  return {
+    start: to24Hour(rawStart ?? "08:00"),
+    end: to24Hour(rawEnd ?? "09:00"),
+  }
+}
+
+function formatTimeRange(start: string, end: string): string {
+  return `${to12Hour(start)} - ${to12Hour(end)}`
+}
+
+function mapSlotToResponse(slot: {
+  id: string
+  className: string
+  day: string
+  startTime: string
+  endTime: string
+  subject: string
+  teacher: string
+  location?: string | null
+}): TimetableSlotResponse {
+  return {
+    id: slot.id,
+    className: slot.className,
+    day: slot.day,
+    subject: slot.subject,
+    teacher: slot.teacher,
+    location: slot.location ?? null,
+    time: formatTimeRange(slot.startTime, slot.endTime),
+  }
+}
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const className = searchParams.get("className") ?? ""
-    const timetable = await dbManager.getTimetable(className)
+    const className = searchParams.get("className") ?? undefined
+
+    const slots = await getTimetableSlots({ className: className ?? undefined })
+    const timetable = slots.map(mapSlotToResponse)
+
     return NextResponse.json({ timetable })
   } catch (error) {
-    console.error("Failed to fetch timetable", error)
+    logger.error("Failed to fetch timetable", { error })
     return NextResponse.json({ error: "Failed to fetch timetable" }, { status: 500 })
   }
 }
@@ -18,16 +107,29 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const className = body?.className
+    const className = typeof body?.className === "string" ? body.className.trim() : ""
+    const slot = body?.slot
 
-    if (!className || !body?.slot) {
+    if (!className || !slot) {
       return NextResponse.json({ error: "Class name and slot are required" }, { status: 400 })
     }
 
-    const slot = await dbManager.addTimetableSlot(className, body.slot)
-    return NextResponse.json({ slot }, { status: 201 })
+    const { start, end } = parseTimeRange(String(slot.time ?? ""))
+
+    const created = await createTimetableSlot({
+      id: slot.id,
+      className,
+      day: String(slot.day ?? "Monday"),
+      startTime: start,
+      endTime: end,
+      subject: String(slot.subject ?? ""),
+      teacher: String(slot.teacher ?? ""),
+      location: typeof slot.location === "string" ? slot.location : null,
+    })
+
+    return NextResponse.json({ slot: mapSlotToResponse(created) }, { status: 201 })
   } catch (error) {
-    console.error("Failed to create timetable slot", error)
+    logger.error("Failed to create timetable slot", { error })
     return NextResponse.json({ error: "Failed to create timetable slot" }, { status: 500 })
   }
 }
@@ -35,21 +137,52 @@ export async function POST(request: NextRequest) {
 export async function PUT(request: NextRequest) {
   try {
     const body = await request.json()
-    const className = body?.className
-    const slotId = body?.slotId
+    const slotId = typeof body?.slotId === "string" ? body.slotId : undefined
+    const updates = body?.updates ?? body
 
-    if (!className || !slotId) {
-      return NextResponse.json({ error: "Class name and slot ID are required" }, { status: 400 })
+    if (!slotId) {
+      return NextResponse.json({ error: "Slot ID is required" }, { status: 400 })
     }
 
-    const slot = await dbManager.updateTimetableSlot(className, slotId, body.updates ?? body)
+    const updatePayload: Record<string, unknown> = {}
+
+    if (typeof updates.day === "string") {
+      updatePayload.day = updates.day
+    }
+
+    if (typeof updates.subject === "string") {
+      updatePayload.subject = updates.subject
+    }
+
+    if (typeof updates.teacher === "string") {
+      updatePayload.teacher = updates.teacher
+    }
+
+    if (typeof updates.location === "string" || updates.location === null) {
+      updatePayload.location = updates.location
+    }
+
+    if (typeof updates.time === "string") {
+      const { start, end } = parseTimeRange(updates.time)
+      updatePayload.startTime = start
+      updatePayload.endTime = end
+    } else {
+      if (typeof updates.startTime === "string") {
+        updatePayload.startTime = updates.startTime
+      }
+      if (typeof updates.endTime === "string") {
+        updatePayload.endTime = updates.endTime
+      }
+    }
+
+    const slot = await updateTimetableSlot(slotId, updatePayload)
     if (!slot) {
       return NextResponse.json({ error: "Timetable slot not found" }, { status: 404 })
     }
 
-    return NextResponse.json({ slot })
+    return NextResponse.json({ slot: mapSlotToResponse(slot) })
   } catch (error) {
-    console.error("Failed to update timetable slot", error)
+    logger.error("Failed to update timetable slot", { error })
     return NextResponse.json({ error: "Failed to update timetable slot" }, { status: 500 })
   }
 }
@@ -57,21 +190,20 @@ export async function PUT(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const className = searchParams.get("className")
-    const slotId = searchParams.get("slotId")
+    const slotId = searchParams.get("slotId") ?? undefined
 
-    if (!className || !slotId) {
-      return NextResponse.json({ error: "Class name and slot ID are required" }, { status: 400 })
+    if (!slotId) {
+      return NextResponse.json({ error: "Slot ID is required" }, { status: 400 })
     }
 
-    const removed = await dbManager.deleteTimetableSlot(className, slotId)
+    const removed = await deleteTimetableSlot(slotId)
     if (!removed) {
       return NextResponse.json({ error: "Timetable slot not found" }, { status: 404 })
     }
 
     return NextResponse.json({ success: true })
   } catch (error) {
-    console.error("Failed to delete timetable slot", error)
+    logger.error("Failed to delete timetable slot", { error })
     return NextResponse.json({ error: "Failed to delete timetable slot" }, { status: 500 })
   }
 }

--- a/components/noticeboard.tsx
+++ b/components/noticeboard.tsx
@@ -1,24 +1,28 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
-import { Calendar, Bell, Plus, Pin, Users, BookOpen, Loader2 } from "lucide-react"
-import { dbManager } from "@/lib/database-manager"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+import { Bell, BookOpen, Calendar, Loader2, Pin, Plus, Users } from "lucide-react"
+import { logger } from "@/lib/logger"
+import { useToast } from "@/hooks/use-toast"
 
 interface Notice {
   id: string
   title: string
   content: string
-  category: "general" | "academic" | "event" | "urgent"
+  category: "general" | "academic" | "event" | "urgent" | "celebration"
   targetAudience: string[]
   author: string
+  authorRole: string
   date: string
   isPinned: boolean
 }
@@ -28,120 +32,224 @@ interface NoticeboardProps {
   userName?: string
 }
 
+const AUDIENCE_OPTIONS = ["student", "teacher", "parent", "admin"] as const
+
+const FALLBACK_NOTICES: Notice[] = [
+  {
+    id: "notice_seed_1",
+    title: "Mid-Term Examination Schedule",
+    content:
+      "The mid-term examinations will commence on January 20th, 2025. All students are expected to be present and punctual.",
+    category: "academic",
+    targetAudience: ["student", "parent", "teacher"],
+    author: "Academic Office",
+    authorRole: "admin",
+    date: "2025-01-08",
+    isPinned: true,
+  },
+  {
+    id: "notice_seed_2",
+    title: "Parent-Teacher Conference",
+    content:
+      "We invite all parents to attend the quarterly parent-teacher conference scheduled for January 25th, 2025.",
+    category: "event",
+    targetAudience: ["parent", "teacher"],
+    author: "Principal's Office",
+    authorRole: "admin",
+    date: "2025-01-07",
+    isPinned: true,
+  },
+]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseAudience(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => (typeof entry === "string" ? entry : null))
+    .filter((entry): entry is string => entry !== null)
+}
+
+function toNotice(value: unknown): Notice {
+  if (!isRecord(value)) {
+    return {
+      id: `notice_${Date.now()}`,
+      title: "Untitled",
+      content: "",
+      category: "general",
+      targetAudience: [],
+      author: "School Administration",
+      authorRole: "admin",
+      date: new Date().toISOString(),
+      isPinned: false,
+    }
+  }
+
+  const idCandidate = value.id
+  const generatedId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `notice_${Date.now()}`
+
+  return {
+    id: typeof idCandidate === "string" && idCandidate ? idCandidate : String(idCandidate ?? generatedId),
+    title: typeof value.title === "string" && value.title.trim().length > 0 ? value.title : "Untitled",
+    content: typeof value.content === "string" ? value.content : "",
+    category: (value.category as Notice["category"]) ?? "general",
+    targetAudience: parseAudience(value.targetAudience),
+    author: typeof value.author === "string" ? value.author : String(value.authorName ?? "School Administration"),
+    authorRole: typeof value.authorRole === "string" ? value.authorRole : "admin",
+    date: typeof value.date === "string" ? value.date : String(value.createdAt ?? new Date().toISOString()),
+    isPinned: Boolean(value.isPinned),
+  }
+}
+
 export function Noticeboard({ userRole, userName }: NoticeboardProps) {
   const [notices, setNotices] = useState<Notice[]>([])
-  const [loading, setLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [showCreateForm, setShowCreateForm] = useState(false)
-  const [saving, setSaving] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
   const [newNotice, setNewNotice] = useState({
     title: "",
     content: "",
     category: "general" as Notice["category"],
     targetAudience: [] as string[],
   })
+  const { toast } = useToast()
 
   const canCreateNotice = userRole === "admin" || userRole === "teacher"
 
-  useEffect(() => {
-    loadNotices()
-
-    const handleNoticeUpdate = () => {
-      loadNotices()
-    }
-
-    dbManager.on("noticeCreated", handleNoticeUpdate)
-    dbManager.on("noticeUpdated", handleNoticeUpdate)
-    dbManager.on("noticeDeleted", handleNoticeUpdate)
-
-    return () => {
-      dbManager.off("noticeCreated", handleNoticeUpdate)
-      dbManager.off("noticeUpdated", handleNoticeUpdate)
-      dbManager.off("noticeDeleted", handleNoticeUpdate)
-    }
-  }, [])
-
-  const loadNotices = async () => {
+  const loadNotices = useCallback(async () => {
     try {
-      setLoading(true)
-      const noticesData = await dbManager.getNotices()
-      setNotices(noticesData)
-    } catch (error) {
-      console.error("Error loading notices:", error)
-      setNotices([
-        {
-          id: "1",
-          title: "Mid-Term Examination Schedule",
-          content:
-            "The mid-term examinations will commence on January 20th, 2025. All students are expected to be present and punctual.",
-          category: "academic",
-          targetAudience: ["student", "parent", "teacher"],
-          author: "Academic Office",
-          date: "2025-01-08",
-          isPinned: true,
-        },
-        {
-          id: "2",
-          title: "Parent-Teacher Conference",
-          content:
-            "We invite all parents to attend the quarterly parent-teacher conference scheduled for January 25th, 2025.",
-          category: "event",
-          targetAudience: ["parent", "teacher"],
-          author: "Principal's Office",
-          date: "2025-01-07",
-          isPinned: true,
-        },
-      ])
-    } finally {
-      setLoading(false)
-    }
-  }
+      setIsLoading(true)
+      setError(null)
 
-  const handleCreateNotice = async (e: React.FormEvent) => {
-    e.preventDefault()
+      const params = new URLSearchParams({ audience: userRole })
+      const response = await fetch(`/api/noticeboard?${params.toString()}`, {
+        cache: "no-store",
+      })
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`)
+      }
+
+      const data: unknown = await response.json()
+      const incoming: Notice[] = Array.isArray((data as Record<string, unknown>)?.notices)
+        ? ((data as Record<string, unknown>).notices as unknown[]).map(toNotice)
+        : []
+
+      setNotices(incoming.length > 0 ? incoming : FALLBACK_NOTICES)
+    } catch (err) {
+      logger.error("Error loading notices", { error: err })
+      setError("We could not load notices from the server. Displaying the last known updates.")
+      setNotices(FALLBACK_NOTICES)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [userRole])
+
+  useEffect(() => {
+    void loadNotices()
+  }, [loadNotices])
+
+  const filteredNotices = useMemo(() => {
+    if (userRole === "admin") {
+      return notices
+    }
+
+    return notices.filter((notice) => notice.targetAudience.includes(userRole))
+  }, [notices, userRole])
+
+  const pinnedNotices = useMemo(
+    () => filteredNotices.filter((notice) => notice.isPinned),
+    [filteredNotices],
+  )
+  const regularNotices = useMemo(
+    () => filteredNotices.filter((notice) => !notice.isPinned),
+    [filteredNotices],
+  )
+
+  const handleCreateNotice = async (event: React.FormEvent) => {
+    event.preventDefault()
 
     if (newNotice.targetAudience.length === 0) {
-      alert("Please select at least one target audience")
+      toast({
+        variant: "destructive",
+        title: "Target audience required",
+        description: "Select at least one audience segment before publishing a notice.",
+      })
       return
     }
 
     try {
-      setSaving(true)
+      setIsSaving(true)
+      const response = await fetch("/api/noticeboard", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: newNotice.title,
+          content: newNotice.content,
+          category: newNotice.category,
+          targetAudience: newNotice.targetAudience,
+          authorName: userName ?? "School Administrator",
+          authorRole: userRole,
+        }),
+      })
 
-      const notice: Notice = {
-        id: Date.now().toString(),
-        title: newNotice.title,
-        content: newNotice.content,
-        category: newNotice.category,
-        targetAudience: newNotice.targetAudience,
-        author: userName || "Unknown",
-        date: new Date().toISOString().split("T")[0],
-        isPinned: false,
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+        throw new Error(typeof payload.error === "string" ? payload.error : "Failed to create notice")
       }
 
-      await dbManager.createNotice(notice)
       setNewNotice({ title: "", content: "", category: "general", targetAudience: [] })
       setShowCreateForm(false)
-
       await loadNotices()
-    } catch (error) {
-      console.error("Error creating notice:", error)
-      alert("Failed to create notice. Please try again.")
+    } catch (err) {
+      logger.error("Error creating notice", { error: err })
+      toast({
+        variant: "destructive",
+        title: "Unable to create notice",
+        description: err instanceof Error ? err.message : "Failed to create notice. Please try again.",
+      })
     } finally {
-      setSaving(false)
+      setIsSaving(false)
     }
   }
 
   const togglePin = async (id: string) => {
+    const target = notices.find((notice) => notice.id === id)
+    if (!target) {
+      return
+    }
+
     try {
-      const notice = notices.find((n) => n.id === id)
-      if (notice) {
-        const updatedNotice = { ...notice, isPinned: !notice.isPinned }
-        await dbManager.updateNotice(id, updatedNotice)
-        await loadNotices()
+      const response = await fetch(`/api/noticeboard/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isPinned: !target.isPinned }),
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>
+        throw new Error(typeof payload.error === "string" ? payload.error : "Unable to update notice")
       }
-    } catch (error) {
-      console.error("Error updating notice pin status:", error)
-      alert("Failed to update notice. Please try again.")
+
+      await loadNotices()
+    } catch (err) {
+      logger.error("Error updating notice pin status", { error: err })
+      toast({
+        variant: "destructive",
+        title: "Unable to update notice",
+        description: err instanceof Error ? err.message : "Failed to update notice. Please try again.",
+      })
     }
   }
 
@@ -153,6 +261,8 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
         return "bg-blue-100 text-blue-800 border-blue-200"
       case "event":
         return "bg-purple-100 text-purple-800 border-purple-200"
+      case "celebration":
+        return "bg-amber-100 text-amber-800 border-amber-200"
       default:
         return "bg-gray-100 text-gray-800 border-gray-200"
     }
@@ -171,11 +281,7 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
     }
   }
 
-  const filteredNotices = notices.filter((notice) => notice.targetAudience.includes(userRole) || userRole === "admin")
-  const pinnedNotices = filteredNotices.filter((notice) => notice.isPinned)
-  const regularNotices = filteredNotices.filter((notice) => !notice.isPinned)
-
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="h-8 w-8 animate-spin text-[#2d682d]" />
@@ -192,14 +298,34 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
           <p className="text-gray-600">Important announcements and updates</p>
         </div>
         {canCreateNotice && (
-          <Button onClick={() => setShowCreateForm(true)} className="bg-[#2d682d] hover:bg-[#1a4a1a] text-white">
+          <Button
+            onClick={() => setShowCreateForm(true)}
+            className="bg-[#2d682d] hover:bg-[#1a4a1a] text-white"
+          >
             <Plus className="h-4 w-4 mr-2" />
             Create Notice
           </Button>
         )}
       </div>
 
-      {/* Create Notice Form */}
+      {error && (
+        <Card className="border-[#b29032]/30 bg-[#b29032]/10">
+          <CardContent className="py-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-[#8a6b25]">{error}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => loadNotices()}
+                className="border-[#b29032]/40 text-[#b29032]"
+              >
+                Retry
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {showCreateForm && canCreateNotice && (
         <Card className="border-[#b29032]/20">
           <CardHeader>
@@ -213,10 +339,12 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                 <Input
                   id="notice-title"
                   value={newNotice.title}
-                  onChange={(e) => setNewNotice((prev) => ({ ...prev, title: e.target.value }))}
+                  onChange={(event) =>
+                    setNewNotice((prev) => ({ ...prev, title: event.target.value }))
+                  }
                   placeholder="Enter notice title"
                   required
-                  disabled={saving}
+                  disabled={isSaving}
                 />
               </div>
               <div className="space-y-2">
@@ -224,14 +352,16 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                 <Textarea
                   id="notice-content"
                   value={newNotice.content}
-                  onChange={(e) => setNewNotice((prev) => ({ ...prev, content: e.target.value }))}
+                  onChange={(event) =>
+                    setNewNotice((prev) => ({ ...prev, content: event.target.value }))
+                  }
                   placeholder="Enter notice content"
                   rows={4}
                   required
-                  disabled={saving}
+                  disabled={isSaving}
                 />
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="notice-category">Category</Label>
                   <Select
@@ -239,15 +369,16 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                     onValueChange={(value: Notice["category"]) =>
                       setNewNotice((prev) => ({ ...prev, category: value }))
                     }
-                    disabled={saving}
+                    disabled={isSaving}
                   >
-                    <SelectTrigger>
-                      <SelectValue />
+                    <SelectTrigger id="notice-category">
+                      <SelectValue placeholder="Select a category" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="general">General</SelectItem>
                       <SelectItem value="academic">Academic</SelectItem>
                       <SelectItem value="event">Event</SelectItem>
+                      <SelectItem value="celebration">Celebration</SelectItem>
                       <SelectItem value="urgent">Urgent</SelectItem>
                     </SelectContent>
                   </Select>
@@ -255,44 +386,46 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                 <div className="space-y-2">
                   <Label>Target Audience</Label>
                   <div className="flex flex-wrap gap-2">
-                    {["student", "parent", "teacher"].map((audience) => (
-                      <Button
-                        key={audience}
-                        type="button"
-                        size="sm"
-                        variant={newNotice.targetAudience.includes(audience) ? "default" : "outline"}
-                        onClick={() => {
-                          const updated = newNotice.targetAudience.includes(audience)
-                            ? newNotice.targetAudience.filter((a) => a !== audience)
-                            : [...newNotice.targetAudience, audience]
-                          setNewNotice((prev) => ({ ...prev, targetAudience: updated }))
-                        }}
-                        className={
-                          newNotice.targetAudience.includes(audience)
-                            ? "bg-[#2d682d] hover:bg-[#1a4a1a] text-white"
-                            : "border-[#2d682d] text-[#2d682d] hover:bg-[#2d682d] hover:text-white"
-                        }
-                        disabled={saving}
-                      >
-                        {audience.charAt(0).toUpperCase() + audience.slice(1)}
-                      </Button>
-                    ))}
+                    {AUDIENCE_OPTIONS.map((audience) => {
+                      const isActive = newNotice.targetAudience.includes(audience)
+                      return (
+                        <Button
+                          key={audience}
+                          type="button"
+                          variant={isActive ? "default" : "outline"}
+                          className={cn(
+                            "capitalize",
+                            isActive ? "bg-[#2d682d] hover:bg-[#1a4a1a]" : "text-[#2d682d]",
+                          )}
+                          disabled={isSaving}
+                          onClick={() => {
+                            setNewNotice((prev) => {
+                              const updated = isActive
+                                ? prev.targetAudience.filter((value) => value !== audience)
+                                : [...prev.targetAudience, audience]
+                              return { ...prev, targetAudience: updated }
+                            })
+                          }}
+                        >
+                          {audience}
+                        </Button>
+                      )
+                    })}
                   </div>
                 </div>
               </div>
-              <div className="flex gap-2">
-                <Button type="submit" className="bg-[#2d682d] hover:bg-[#1a4a1a] text-white" disabled={saving}>
-                  {saving ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Posting...
-                    </>
-                  ) : (
-                    "Post Notice"
-                  )}
-                </Button>
-                <Button type="button" variant="outline" onClick={() => setShowCreateForm(false)} disabled={saving}>
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setShowCreateForm(false)}
+                  disabled={isSaving}
+                >
                   Cancel
+                </Button>
+                <Button type="submit" className="bg-[#2d682d]" disabled={isSaving}>
+                  {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Post Notice
                 </Button>
               </div>
             </form>
@@ -300,7 +433,6 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
         </Card>
       )}
 
-      {/* Pinned Notices */}
       {pinnedNotices.length > 0 && (
         <div className="space-y-4">
           <h4 className="text-lg font-medium text-[#2d682d] flex items-center gap-2">
@@ -314,7 +446,7 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-2">
-                        <Badge className={`${getCategoryColor(notice.category)} text-xs`}>
+                        <Badge className={cn(getCategoryColor(notice.category), "text-xs border")}>
                           <span className="flex items-center gap-1">
                             {getCategoryIcon(notice.category)}
                             {notice.category.toUpperCase()}
@@ -340,7 +472,7 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                   </div>
                 </CardHeader>
                 <CardContent className="pt-0">
-                  <p className="text-sm text-gray-700">{notice.content}</p>
+                  <p className="text-sm text-gray-700 whitespace-pre-line">{notice.content}</p>
                 </CardContent>
               </Card>
             ))}
@@ -348,7 +480,6 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
         </div>
       )}
 
-      {/* Regular Notices */}
       <div className="space-y-4">
         <h4 className="text-lg font-medium text-[#2d682d]">Recent Notices</h4>
         <div className="space-y-3">
@@ -358,7 +489,7 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
-                      <Badge className={`${getCategoryColor(notice.category)} text-xs`}>
+                      <Badge className={cn(getCategoryColor(notice.category), "text-xs border")}>
                         <span className="flex items-center gap-1">
                           {getCategoryIcon(notice.category)}
                           {notice.category.toUpperCase()}
@@ -383,7 +514,7 @@ export function Noticeboard({ userRole, userName }: NoticeboardProps) {
                 </div>
               </CardHeader>
               <CardContent className="pt-0">
-                <p className="text-sm text-gray-700">{notice.content}</p>
+                <p className="text-sm text-gray-700 whitespace-pre-line">{notice.content}</p>
               </CardContent>
             </Card>
           ))}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+export type LogLevel = "debug" | "info" | "warn" | "error"
+
+export interface LogContext {
+  [key: string]: unknown
+}
+
+function serializeContext(context?: LogContext): unknown[] {
+  if (!context || Object.keys(context).length === 0) {
+    return []
+  }
+
+  try {
+    return [JSON.parse(JSON.stringify(context))]
+  } catch (error) {
+    return [context]
+  }
+}
+
+function log(level: LogLevel, message: string, context?: LogContext): void {
+  const serializedContext = serializeContext(context)
+
+  switch (level) {
+    case "debug":
+      console.debug(message, ...serializedContext)
+      break
+    case "info":
+      console.info(message, ...serializedContext)
+      break
+    case "warn":
+      console.warn(message, ...serializedContext)
+      break
+    case "error":
+    default:
+      console.error(message, ...serializedContext)
+      break
+  }
+}
+
+export const logger = {
+  debug: (message: string, context?: LogContext) => log("debug", message, context),
+  info: (message: string, context?: LogContext) => log("info", message, context),
+  warn: (message: string, context?: LogContext) => log("warn", message, context),
+  error: (message: string, context?: LogContext) => log("error", message, context),
+}
+
+export function withContext(base: LogContext, additional?: LogContext): LogContext {
+  if (!additional) {
+    return base
+  }
+  return { ...base, ...additional }
+}


### PR DESCRIPTION
## Summary
- add backend endpoints for noticeboard, timetable, analytics, monitoring, and registration backed by the shared database layer and new logger utilities
- extend the database helpers with persistent noticeboard, timetable, analytics, and system metrics handling plus safe storage utilities
- update dashboards (login, noticeboard, analytics, system health, teacher/student views) to consume the APIs, replace alert usage with toast notifications, and harden state restoration via safeStorage

## Testing
- `pnpm lint` *(fails: repository has numerous pre-existing eslint violations in untouched files such as legacy API handlers and dashboard modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ced5be1c7c8327999b644e8123e360