### PR TITLE
Integrate dynamic school branding across reports and receipts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,7 @@ import { InternalMessaging } from "@/components/internal-messaging"
 import { AdminApprovalDashboard } from "@/components/admin-approval-dashboard"
 import { getCompleteReportCard } from "@/lib/sample-report-data"
 import { safeStorage } from "@/lib/safe-storage"
+import { getBrandingFromStorage } from "@/lib/branding"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { toast } from "@/hooks/use-toast"
@@ -888,6 +889,8 @@ function ParentDashboard({ user }: { user: User }) {
   const handleViewReportCard = async () => {
     if (hasAccess) {
       try {
+        const brandingInfo = getBrandingFromStorage()
+
         const approvedReports = JSON.parse(safeStorage.getItem("approvedReports") || "[]")
 
         if (!approvedReports.includes(studentData.id)) {
@@ -938,13 +941,15 @@ function ParentDashboard({ user }: { user: User }) {
             remarks: {
               classTeacher: data.classTeacherRemarks,
               headmaster:
-                safeStorage.getItem("defaultRemarks") ||
+                brandingInfo.defaultRemark ||
                 "An exemplary student who continues to excel in academics and character development.",
             },
             branding: {
-              logo: safeStorage.getItem("schoolLogo") || "",
-              signature: safeStorage.getItem("headmasterSignature") || "",
-              headmasterName: safeStorage.getItem("headmasterName") || "Dr. Victory Adebayo",
+              logo: brandingInfo.logoUrl ?? "",
+              signature: brandingInfo.signatureUrl ?? "",
+              headmasterName: brandingInfo.headmasterName,
+              schoolName: brandingInfo.schoolName,
+              address: brandingInfo.schoolAddress,
             },
             attendance: {
               present: attendanceData.presentDays,

--- a/components/accountant-dashboard.tsx
+++ b/components/accountant-dashboard.tsx
@@ -28,6 +28,7 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react"
+import { useBranding } from "@/hooks/use-branding"
 
 interface AccountantDashboardProps {
   accountant: {
@@ -155,6 +156,13 @@ function mapReceipt(record: ApiReceiptRecord): ReceiptRecord {
 }
 
 export function AccountantDashboard({ accountant }: AccountantDashboardProps) {
+  const branding = useBranding()
+  const resolvedLogo = branding.logoUrl
+  const resolvedSignature = branding.signatureUrl
+  const resolvedSchoolName = branding.schoolName
+  const resolvedAddress = branding.schoolAddress
+  const resolvedHeadmasterName = branding.headmasterName
+
   const [selectedTab, setSelectedTab] = useState("overview")
   const [showFeeDialog, setShowFeeDialog] = useState(false)
   const [showReceiptDialog, setShowReceiptDialog] = useState(false)
@@ -876,9 +884,35 @@ export function AccountantDashboard({ accountant }: AccountantDashboardProps) {
             <DialogDescription>Receipt for {selectedReceipt?.studentName}</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 rounded-lg border bg-gray-50 p-4">
-            <div className="text-center">
-              <h3 className="font-bold text-[#2d682d]">VICTORY EDUCATIONAL ACADEMY</h3>
-              <p className="text-sm">Official Payment Receipt</p>
+            <div className="flex flex-col gap-4 border-b border-dashed border-gray-300 pb-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                  {resolvedLogo ? (
+                    <img
+                      src={resolvedLogo}
+                      alt={`${resolvedSchoolName} logo`}
+                      className="h-12 w-12 object-contain"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-full border border-[#2d682d]/40 flex items-center justify-center text-[10px] font-bold text-[#2d682d]">
+                      LOGO
+                    </div>
+                  )}
+                  <div>
+                    <h3 className="font-bold text-[#2d682d] uppercase tracking-wide">{resolvedSchoolName}</h3>
+                    <p className="text-xs text-gray-600 max-w-[220px]">{resolvedAddress}</p>
+                  </div>
+                </div>
+                <div className="text-right text-xs text-gray-500">
+                  <p className="font-semibold text-[#2d682d]">
+                    Receipt #{selectedReceipt?.receiptNumber ?? "--"}
+                  </p>
+                  <p>{selectedReceipt?.dateIssued ?? "--"}</p>
+                </div>
+              </div>
+              <p className="text-sm font-medium text-gray-600 text-center uppercase tracking-wide">
+                Official Payment Receipt
+              </p>
             </div>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
@@ -897,9 +931,28 @@ export function AccountantDashboard({ accountant }: AccountantDashboardProps) {
                 <span>Date:</span>
                 <span className="font-medium">{selectedReceipt?.dateIssued ?? "--"}</span>
               </div>
-              <div className="flex justify-between">
-                <span>Issued By:</span>
-                <span className="font-medium">{selectedReceipt?.issuedBy ?? accountant.name}</span>
+            </div>
+            <div className="pt-4 border-t border-dashed border-gray-300">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <div className="text-sm text-gray-600">
+                  <p>
+                    <span className="font-medium text-[#2d682d]">Accountant:</span> {selectedReceipt?.issuedBy ?? accountant.name}
+                  </p>
+                  <p className="text-xs text-gray-500">Thank you for keeping your account up to date.</p>
+                </div>
+                <div className="text-right">
+                  {resolvedSignature ? (
+                    <img
+                      src={resolvedSignature}
+                      alt={`${resolvedHeadmasterName} signature`}
+                      className="h-12 w-32 object-contain ml-auto"
+                    />
+                  ) : (
+                    <div className="h-12 w-32 border-b border-[#2d682d]/60 ml-auto"></div>
+                  )}
+                  <p className="mt-2 text-xs font-semibold text-[#2d682d] uppercase">{resolvedHeadmasterName}</p>
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Headmaster</p>
+                </div>
               </div>
             </div>
           </div>
@@ -912,14 +965,38 @@ export function AccountantDashboard({ accountant }: AccountantDashboardProps) {
                 if (typeof window !== "undefined" && selectedReceipt) {
                   const printWindow = window.open("", "PRINT", "height=600,width=400")
                   if (printWindow) {
-                    printWindow.document.write("<html><head><title>Receipt</title></head><body>")
-                    printWindow.document.write(`<h2 style="color:#2d682d;text-align:center;">Victory Educational Academy</h2>`)
-                    printWindow.document.write(`<p><strong>Receipt Number:</strong> ${selectedReceipt.receiptNumber}</p>`)
+                    const logoMarkup = resolvedLogo
+                      ? `<div style="text-align:center;margin-bottom:12px;"><img src="${resolvedLogo}" alt="${resolvedSchoolName} logo" style="height:64px;object-fit:contain;" /></div>`
+                      : `<h2 style="color:#2d682d;text-align:center;margin-bottom:4px;">${resolvedSchoolName}</h2>`
+                    const headerMarkup = `
+                      <div style="text-align:center;">
+                        ${logoMarkup}
+                        <p style="margin:0;font-weight:700;color:#2d682d;text-transform:uppercase;">${resolvedSchoolName}</p>
+                        <p style="margin:0;color:#555;font-size:12px;">${resolvedAddress}</p>
+                        <p style="margin-top:8px;font-size:13px;font-weight:600;color:#444;">Official Payment Receipt</p>
+                      </div>
+                    `
+                    const signatureMarkup = resolvedSignature
+                      ? `<div style="margin-top:32px;text-align:right;">
+                          <img src="${resolvedSignature}" alt="${resolvedHeadmasterName} signature" style="height:48px;width:160px;object-fit:contain;margin-bottom:4px;" />
+                          <div style="font-size:11px;font-weight:bold;color:#2d682d;text-transform:uppercase;">${resolvedHeadmasterName}</div>
+                          <div style="font-size:10px;color:#777;">Headmaster</div>
+                        </div>`
+                      : `<div style="margin-top:32px;text-align:right;">
+                          <div style="height:48px;width:160px;border-bottom:1px solid #2d682d66;margin-left:auto;"></div>
+                          <div style="font-size:11px;font-weight:bold;color:#2d682d;text-transform:uppercase;margin-top:4px;">${resolvedHeadmasterName}</div>
+                          <div style="font-size:10px;color:#777;">Headmaster</div>
+                        </div>`
+
+                    printWindow.document.write("<html><head><title>Receipt</title></head><body style=\"font-family:Arial,sans-serif;padding:24px;color:#222;\">")
+                    printWindow.document.write(headerMarkup)
+                    printWindow.document.write(`<p style="margin-top:16px;"><strong>Receipt Number:</strong> ${selectedReceipt.receiptNumber}</p>`)
                     printWindow.document.write(`<p><strong>Student:</strong> ${selectedReceipt.studentName}</p>`)
                     printWindow.document.write(`<p><strong>Amount:</strong> ${formatCurrency(selectedReceipt.amount)}</p>`)
                     printWindow.document.write(`<p><strong>Reference:</strong> ${selectedReceipt.reference ?? "--"}</p>`)
                     printWindow.document.write(`<p><strong>Date:</strong> ${selectedReceipt.dateIssued}</p>`)
-                    printWindow.document.write(`<p><strong>Issued By:</strong> ${selectedReceipt.issuedBy ?? accountant.name}</p>`)
+                    printWindow.document.write(`<p><strong>Accountant:</strong> ${selectedReceipt.issuedBy ?? accountant.name}</p>`)
+                    printWindow.document.write(signatureMarkup)
                     printWindow.document.write("</body></html>")
                     printWindow.document.close()
                     printWindow.focus()

--- a/components/cumulative-report.tsx
+++ b/components/cumulative-report.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useToast } from "@/hooks/use-toast"
 import { dbManager } from "@/lib/database-manager"
 import { Download, GraduationCap, Loader2, Printer, TrendingUp, Calendar } from "lucide-react"
+import { useBranding } from "@/hooks/use-branding"
 
 interface CumulativeSubject {
   name: string
@@ -87,6 +88,11 @@ const trendIcon = (trend: SubjectAverage["trend"]) => {
 }
 
 function CumulativeReport({ data, isLoading, error, onRetry }: CumulativeReportProps) {
+  const branding = useBranding()
+  const resolvedSchoolName = branding.schoolName
+  const resolvedAddress = branding.schoolAddress
+  const resolvedLogo = branding.logoUrl
+
   const handlePrint = () => window.print()
 
   if (isLoading) {
@@ -146,10 +152,15 @@ function CumulativeReport({ data, isLoading, error, onRetry }: CumulativeReportP
       <div className="print:p-8 print:bg-white">
         <div className="text-center mb-8 border-b-2 border-[#2d682d] pb-6">
           <div className="flex items-center justify-center mb-4">
-            <GraduationCap className="h-16 w-16 text-[#b29032]" />
+            {resolvedLogo ? (
+              <img src={resolvedLogo} alt={`${resolvedSchoolName} logo`} className="h-20 w-20 object-contain" />
+            ) : (
+              <GraduationCap className="h-16 w-16 text-[#b29032]" />
+            )}
           </div>
-          <h1 className="text-3xl font-bold text-[#2d682d] mb-2">Victory Educational Academy</h1>
-          <p className="text-lg text-gray-600 mb-1">Comprehensive Learning Excellence</p>
+          <h1 className="text-3xl font-bold text-[#2d682d] mb-2">{resolvedSchoolName}</h1>
+          <p className="text-lg text-gray-600 mb-1">{resolvedAddress}</p>
+          <p className="text-sm text-gray-500 italic">{branding.defaultRemark}</p>
           <div className="mt-4">
             <h2 className="text-xl font-semibold text-[#b29032]">CUMULATIVE ACADEMIC REPORT</h2>
             <p className="text-sm text-gray-600">{data.session} Academic Session</p>
@@ -302,14 +313,14 @@ function CumulativeReport({ data, isLoading, error, onRetry }: CumulativeReportP
           </CardContent>
         </Card>
 
-        <div className="text-center border-t-2 border-[#2d682d] pt-6">
-          <p className="text-xs text-gray-500 mb-2">
-            This cumulative report is automatically generated based on approved term results.
-          </p>
-          <div className="text-xs text-gray-400">
-            <p>Victory Educational Academy • Excellence in Education • www.vea2025.edu.ng</p>
+          <div className="text-center border-t-2 border-[#2d682d] pt-6">
+            <p className="text-xs text-gray-500 mb-2">
+              This cumulative report is automatically generated based on approved term results.
+            </p>
+            <div className="text-xs text-gray-400">
+            <p>{resolvedSchoolName} • {resolvedAddress}</p>
+            </div>
           </div>
-        </div>
       </div>
     </DialogContent>
   )

--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Download, PrinterIcon as Print } from "lucide-react"
 import { useEffect, useState } from "react"
+
+import { useBranding } from "@/hooks/use-branding"
 import { safeStorage } from "@/lib/safe-storage"
 
 interface ReportCardData {
@@ -46,10 +48,8 @@ interface ReportCardData {
 }
 
 export function EnhancedReportCard({ data }: { data?: ReportCardData }) {
-  const [schoolLogo, setSchoolLogo] = useState<string>("")
-  const [headmasterSignature, setHeadmasterSignature] = useState<string>("")
+  const branding = useBranding()
   const [studentPhoto, setStudentPhoto] = useState<string>("")
-  const [headmasterName, setHeadmasterName] = useState<string>("Dr. Emmanuel Adebayo")
   const [reportCardData, setReportCardData] = useState<ReportCardData | null>(data || null)
 
   useEffect(() => {
@@ -143,14 +143,6 @@ export function EnhancedReportCard({ data }: { data?: ReportCardData }) {
   }
 
   useEffect(() => {
-    const brandingData = safeStorage.getItem("schoolBranding")
-    if (brandingData) {
-      const branding = JSON.parse(brandingData)
-      setSchoolLogo(branding.logoUrl || "")
-      setHeadmasterSignature(branding.signatureUrl || "")
-      setHeadmasterName(branding.headmasterName || "Dr. Emmanuel Adebayo")
-    }
-
     if (reportCardData?.student?.id) {
       const studentPhotos = safeStorage.getItem("studentPhotos")
       if (studentPhotos) {
@@ -207,36 +199,36 @@ export function EnhancedReportCard({ data }: { data?: ReportCardData }) {
 
       <div className="border-8 border-[#2d682d] print:border-black bg-white print:shadow-none">
         <div className="bg-white p-6">
-          <div className="flex items-start justify-between mb-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-6">
             {/* Left: School Logo */}
-            <div className="w-20 h-20 border-2 border-[#2d682d] print:border-black flex items-center justify-center bg-white">
-              {schoolLogo ? (
+            <div className="w-20 h-20 border-2 border-[#2d682d] print:border-black flex items-center justify-center bg-white mx-auto md:mx-0">
+              {branding.logoUrl ? (
                 <img
-                  src={schoolLogo || "/placeholder.svg"}
-                  alt="School Crest"
+                  src={branding.logoUrl}
+                  alt={`${branding.schoolName} logo`}
                   className="w-full h-full object-contain p-1"
                 />
               ) : (
-                <div className="text-xs text-[#2d682d] print:text-gray-600 text-center font-bold">
+                <div className="text-[10px] text-[#2d682d] print:text-gray-600 text-center font-bold leading-tight">
                   SCHOOL
                   <br />
-                  CREST
+                  LOGO
                 </div>
               )}
             </div>
 
             {/* Center: School Information */}
-            <div className="flex-1 text-center mx-8">
+            <div className="flex-1 text-center md:mx-8">
               <h1 className="text-3xl font-bold text-[#2d682d] print:text-black mb-2 uppercase tracking-wide font-serif">
-                VICTORY EDUCATIONAL ACADEMY
+                {branding.schoolName.toUpperCase()}
               </h1>
               <p className="text-sm text-[#2d682d]/80 print:text-black mb-4 font-medium">
-                No. 19, Abdulazeez Street, Zone 3 Duste Baumpaba, Bwari Area Council, Abuja
+                {branding.schoolAddress}
               </p>
             </div>
 
             {/* Right: Student Photo placeholder */}
-            <div className="w-20 h-24 border-2 border-[#2d682d] print:border-black flex items-center justify-center bg-white">
+            <div className="w-20 h-24 border-2 border-[#2d682d] print:border-black flex items-center justify-center bg-white mx-auto md:mx-0">
               {studentPhoto ? (
                 <img
                   src={studentPhoto || "/placeholder.svg"}
@@ -626,31 +618,31 @@ export function EnhancedReportCard({ data }: { data?: ReportCardData }) {
             </div>
           </div>
 
-          <div className="flex justify-between items-end mb-6">
-            <div className="text-center">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between mb-6">
+            <div className="text-center md:text-left">
               <div className="border-b-2 border-[#2d682d] print:border-black w-48 h-16 mb-2"></div>
               <p className="text-sm font-bold text-[#2d682d] print:text-black">CLASS TEACHER</p>
             </div>
-            <div className="text-center">
-              {headmasterSignature ? (
-                <div className="mb-2">
-                  <img
-                    src={headmasterSignature || "/placeholder.svg"}
-                    alt="Headmaster Signature"
-                    className="h-16 w-48 object-contain mx-auto"
-                  />
-                </div>
+            <div className="flex flex-col items-center md:items-end text-center md:text-right">
+              {branding.signatureUrl ? (
+                <img
+                  src={branding.signatureUrl}
+                  alt={`${branding.headmasterName} signature`}
+                  className="h-16 w-48 object-contain mb-2 md:ml-auto"
+                />
               ) : (
-                <div className="border-b-2 border-[#2d682d] print:border-black w-48 h-16 mb-2"></div>
+                <div className="border-b-2 border-[#2d682d] print:border-black w-48 h-16 mb-2 md:ml-auto"></div>
               )}
-              <p className="text-sm font-bold text-[#2d682d] print:text-black">{headmasterName.toUpperCase()}</p>
+              <p className="text-sm font-bold text-[#2d682d] print:text-black">
+                {branding.headmasterName.toUpperCase()}
+              </p>
               <p className="text-sm font-bold text-[#2d682d] print:text-black">HEADMASTER</p>
             </div>
           </div>
 
           <div className="text-center">
             <p className="text-xs text-[#2d682d] print:text-gray-600 font-medium">
-              © Victory Educational Academy. All rights reserved.
+              © {branding.schoolName}. All rights reserved.
             </p>
           </div>
         </div>

--- a/components/report-card.tsx
+++ b/components/report-card.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { GraduationCap, Download, Printer, Award, Calendar, MapPin, Phone, Mail } from "lucide-react"
+import { useBranding } from "@/hooks/use-branding"
 
 interface Subject {
   name: string
@@ -19,6 +20,14 @@ interface Subject {
   grade: string
   position: number
   teacherComment: string
+}
+
+interface ReportBranding {
+  schoolName?: string
+  address?: string
+  logo?: string | null
+  headmasterSignature?: string | null
+  headmasterName?: string
 }
 
 interface ReportCardData {
@@ -53,6 +62,7 @@ interface ReportCardData {
   principalComment: string
   classTeacherComment: string
   nextTermBegins: string
+  branding?: ReportBranding
 }
 
 const mockReportData: ReportCardData = {
@@ -148,6 +158,11 @@ const mockReportData: ReportCardData = {
   classTeacherComment:
     "A dedicated student with good leadership qualities. Encourage more participation in class discussions.",
   nextTermBegins: "January 15, 2025",
+  branding: {
+    schoolName: "Victory Educational Academy",
+    address: "No. 19, Abdulazeez Street, Zone 3 Duste Baumpaba, Bwari Area Council, Abuja",
+    headmasterName: "Dr. Emmanuel Adebayo",
+  },
 }
 
 interface ReportCardProps {
@@ -157,6 +172,24 @@ interface ReportCardProps {
 }
 
 export function ReportCard({ data, isOpen, onClose }: ReportCardProps) {
+  const branding = useBranding()
+
+  const pickText = (overrideValue: string | undefined, fallbackValue: string) =>
+    overrideValue && overrideValue.trim().length > 0 ? overrideValue : fallbackValue
+
+  const pickOptional = (overrideValue: string | null | undefined, fallbackValue: string | null) => {
+    if (typeof overrideValue === "string" && overrideValue.trim().length > 0) {
+      return overrideValue
+    }
+    return fallbackValue
+  }
+
+  const resolvedSchoolName = pickText(data.branding?.schoolName, branding.schoolName)
+  const resolvedAddress = pickText(data.branding?.address, branding.schoolAddress)
+  const resolvedLogo = pickOptional(data.branding?.logo ?? null, branding.logoUrl)
+  const resolvedSignature = pickOptional(data.branding?.headmasterSignature ?? null, branding.signatureUrl)
+  const resolvedHeadmasterName = pickText(data.branding?.headmasterName, branding.headmasterName)
+
   const handlePrint = () => {
     window.print()
   }
@@ -205,11 +238,15 @@ export function ReportCard({ data, isOpen, onClose }: ReportCardProps) {
           {/* Header */}
           <div className="text-center mb-8 border-b-2 border-[#2d682d] pb-6">
             <div className="flex items-center justify-center mb-4">
-              <GraduationCap className="h-16 w-16 text-[#b29032]" />
+              {resolvedLogo ? (
+                <img src={resolvedLogo} alt={`${resolvedSchoolName} logo`} className="h-20 w-20 object-contain" />
+              ) : (
+                <GraduationCap className="h-16 w-16 text-[#b29032]" />
+              )}
             </div>
-            <h1 className="text-3xl font-bold text-[#2d682d] mb-2">VEA 2025</h1>
-            <p className="text-lg text-gray-600 mb-1">Victory Educational Academy</p>
-            <p className="text-sm text-gray-500">Excellence in Education Since 2020</p>
+            <h1 className="text-3xl font-bold text-[#2d682d] mb-2">{resolvedSchoolName.toUpperCase()}</h1>
+            <p className="text-lg text-gray-600 mb-1">{resolvedAddress}</p>
+            <p className="text-sm text-gray-500 italic">{branding.defaultRemark}</p>
             <div className="mt-4">
               <h2 className="text-xl font-semibold text-[#b29032]">ACADEMIC REPORT CARD</h2>
               <p className="text-sm text-gray-600">
@@ -418,22 +455,38 @@ export function ReportCard({ data, isOpen, onClose }: ReportCardProps) {
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-gray-700 italic">{data.principalComment}</p>
-                <div className="mt-4 pt-4 border-t">
-                  <p className="text-xs text-gray-500">Signature: _________________</p>
-                  <p className="text-xs text-gray-500 mt-1">Date: _________________</p>
-                </div>
               </CardContent>
             </Card>
+          </div>
+
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between mb-6">
+            <div className="text-center md:text-left">
+              <div className="border-b-2 border-[#2d682d] print:border-black w-48 h-16 mb-2"></div>
+              <p className="text-sm font-bold text-[#2d682d]">CLASS TEACHER</p>
+            </div>
+            <div className="flex flex-col items-center md:items-end text-center md:text-right">
+              {resolvedSignature ? (
+                <img
+                  src={resolvedSignature}
+                  alt={`${resolvedHeadmasterName} signature`}
+                  className="h-16 w-48 object-contain mb-2 md:ml-auto"
+                />
+              ) : (
+                <div className="border-b-2 border-[#2d682d] print:border-black w-48 h-16 mb-2 md:ml-auto"></div>
+              )}
+              <p className="text-sm font-bold text-[#2d682d]">{resolvedHeadmasterName.toUpperCase()}</p>
+              <p className="text-sm font-bold text-[#2d682d]">HEADMASTER</p>
+            </div>
           </div>
 
           {/* Footer */}
           <div className="text-center border-t-2 border-[#2d682d] pt-6">
             <p className="text-sm font-semibold text-[#2d682d] mb-2">Next Term Begins: {data.nextTermBegins}</p>
-            <p className="text-xs text-gray-500">
-              This report card is computer generated and does not require a signature
-            </p>
+            <div className="mt-2 text-xs text-gray-500">
+              <p>For further enquiries, please contact the school administration.</p>
+            </div>
             <div className="mt-4 text-xs text-gray-400">
-              <p>Victory Educational Academy • Excellence in Education • www.vea2025.edu.ng</p>
+              <p>{resolvedSchoolName} • {resolvedAddress}</p>
             </div>
           </div>
         </div>

--- a/hooks/use-branding.ts
+++ b/hooks/use-branding.ts
@@ -1,0 +1,48 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { dbManager } from "@/lib/database-manager"
+import {
+  BRANDING_STORAGE_KEY,
+  type BrandingInfo,
+  getBrandingFromStorage,
+  parseBranding,
+} from "@/lib/branding"
+
+const BRANDING_EVENT_KEY = "brandingUpdated"
+
+export const useBranding = (): BrandingInfo => {
+  const [branding, setBranding] = useState<BrandingInfo>(() => getBrandingFromStorage())
+
+  useEffect(() => {
+    const updateBrandingState = (value: unknown) => {
+      setBranding(parseBranding(value ?? getBrandingFromStorage()))
+    }
+
+    const handleStorageEvent = (event: StorageEvent) => {
+      if (!event.key) {
+        return
+      }
+
+      if (event.key === BRANDING_STORAGE_KEY || event.key === BRANDING_EVENT_KEY) {
+        updateBrandingState(event.newValue ?? getBrandingFromStorage())
+      }
+    }
+
+    dbManager.on(BRANDING_EVENT_KEY, updateBrandingState)
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("storage", handleStorageEvent)
+    }
+
+    return () => {
+      dbManager.off(BRANDING_EVENT_KEY, updateBrandingState)
+      if (typeof window !== "undefined") {
+        window.removeEventListener("storage", handleStorageEvent)
+      }
+    }
+  }, [])
+
+  return branding
+}

--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -1,0 +1,89 @@
+import { safeStorage } from "./safe-storage"
+
+export interface BrandingInfo {
+  schoolName: string
+  schoolAddress: string
+  headmasterName: string
+  defaultRemark: string
+  logoUrl: string | null
+  signatureUrl: string | null
+  updatedAt?: string
+}
+
+export const BRANDING_STORAGE_KEY = "schoolBranding"
+
+const FALLBACK_BRANDING: BrandingInfo = {
+  schoolName: "Victory Educational Academy",
+  schoolAddress: "No. 19, Abdulazeez Street, Zone 3 Duste Baumpaba, Bwari Area Council, Abuja",
+  headmasterName: "Dr. Emmanuel Adebayo",
+  defaultRemark: "Keep up the excellent work and continue to strive for academic excellence.",
+  logoUrl: null,
+  signatureUrl: null,
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const normalizeOptionalUrl = (value: unknown): string | null => {
+  if (isNonEmptyString(value)) {
+    return value
+  }
+  return null
+}
+
+const normalizeBrandingObject = (value: Partial<BrandingInfo> | null | undefined): BrandingInfo => {
+  if (!value || typeof value !== "object") {
+    return { ...FALLBACK_BRANDING }
+  }
+
+  return {
+    schoolName: isNonEmptyString(value.schoolName) ? value.schoolName.trim() : FALLBACK_BRANDING.schoolName,
+    schoolAddress: isNonEmptyString(value.schoolAddress)
+      ? value.schoolAddress.trim()
+      : FALLBACK_BRANDING.schoolAddress,
+    headmasterName: isNonEmptyString(value.headmasterName)
+      ? value.headmasterName.trim()
+      : FALLBACK_BRANDING.headmasterName,
+    defaultRemark: isNonEmptyString(value.defaultRemark)
+      ? value.defaultRemark.trim()
+      : FALLBACK_BRANDING.defaultRemark,
+    logoUrl: normalizeOptionalUrl(value.logoUrl),
+    signatureUrl: normalizeOptionalUrl(value.signatureUrl),
+    updatedAt: isNonEmptyString(value.updatedAt) ? value.updatedAt : undefined,
+  }
+}
+
+export const parseBranding = (rawValue: unknown): BrandingInfo => {
+  if (typeof rawValue === "string") {
+    if (!rawValue.trim().length) {
+      return { ...FALLBACK_BRANDING }
+    }
+
+    try {
+      const parsed = JSON.parse(rawValue) as Partial<BrandingInfo>
+      return normalizeBrandingObject(parsed)
+    } catch (error) {
+      return { ...FALLBACK_BRANDING }
+    }
+  }
+
+  if (typeof rawValue === "object" && rawValue !== null) {
+    return normalizeBrandingObject(rawValue as Partial<BrandingInfo>)
+  }
+
+  return { ...FALLBACK_BRANDING }
+}
+
+export const getBrandingFromStorage = () => {
+  try {
+    const value = safeStorage.getItem(BRANDING_STORAGE_KEY)
+    if (value === null) {
+      return { ...FALLBACK_BRANDING }
+    }
+    return parseBranding(value)
+  } catch (error) {
+    return { ...FALLBACK_BRANDING }
+  }
+}
+
+export const getFallbackBranding = (): BrandingInfo => ({ ...FALLBACK_BRANDING })

--- a/lib/sample-report-data.ts
+++ b/lib/sample-report-data.ts
@@ -1,4 +1,7 @@
 import { safeStorage } from "@/lib/safe-storage"
+import { getBrandingFromStorage } from "./branding"
+
+const fallbackBrandingInfo = getBrandingFromStorage()
 
 export const completeReportCardData = {
   // Complete report card data for John Doe - JSS 1A Mathematics
@@ -108,11 +111,11 @@ export const completeReportCardData = {
     nextTermBegins: "2025-01-15",
     vacationEnds: "2025-01-14",
     branding: {
-      schoolName: "VICTORY EDUCATIONAL ACADEMY",
-      address: "No. 19, Abdulazeez Street, Zone 3 Duste Baumpaba, Bwari Area Council, Abuja",
-      logo: safeStorage.getItem("schoolLogo") || "/generic-school-logo.png",
-      headmasterSignature: safeStorage.getItem("headmasterSignature") || "",
-      headmasterName: safeStorage.getItem("headmasterName") || "Dr. Victory Adebayo",
+      schoolName: fallbackBrandingInfo.schoolName,
+      address: fallbackBrandingInfo.schoolAddress,
+      logo: fallbackBrandingInfo.logoUrl ?? "/generic-school-logo.png",
+      headmasterSignature: fallbackBrandingInfo.signatureUrl ?? "",
+      headmasterName: fallbackBrandingInfo.headmasterName,
     },
   },
 }


### PR DESCRIPTION
## Summary
- add a reusable branding helper and hook so client components can react to super admin logo and signature updates
- refresh report card, cumulative report, and receipt UIs to display the uploaded school branding with a right-aligned signature block
- source sample/parent dashboard branding data from the shared storage defaults to keep assets consistent

## Testing
- pnpm lint *(fails: existing lint warnings and no-restricted-globals errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ceeb890ec08327a3cd4063657d38fe