### PR TITLE
Implement assignment materials and fee delivery workflows

### DIFF
--- a/app/api/assignments/route.ts
+++ b/app/api/assignments/route.ts
@@ -26,7 +26,21 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { title, description, subject, classId, teacherId, dueDate, type } = body
+    const {
+      title,
+      description,
+      subject,
+      classId,
+      className,
+      teacherId,
+      teacherName,
+      dueDate,
+      type,
+      attachmentName,
+      attachmentSize,
+      attachmentType,
+      attachmentData,
+    } = body
 
     if (type === "submission") {
       const { assignmentId, studentId, files } = body
@@ -48,9 +62,20 @@ export async function POST(request: NextRequest) {
         description,
         subject,
         classId,
+        className,
         teacherId,
+        teacherName,
         dueDate,
-        status: "active",
+        status: "sent",
+        resourceName: attachmentName ?? null,
+        resourceSize:
+          typeof attachmentSize === "number"
+            ? attachmentSize
+            : attachmentSize
+              ? Number(attachmentSize)
+              : null,
+        resourceType: attachmentType ?? null,
+        resourceUrl: typeof attachmentData === "string" ? attachmentData : null,
       })
 
       return NextResponse.json({

--- a/app/api/payments/fee-structure/route.ts
+++ b/app/api/payments/fee-structure/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-import { listFeeStructures, upsertFeeStructure } from "@/lib/database"
+import { deleteFeeStructureRecord, listFeeStructures, upsertFeeStructure } from "@/lib/database"
 import { sanitizeInput } from "@/lib/security"
 
 export const runtime = "nodejs"
@@ -48,5 +48,27 @@ export async function POST(request: NextRequest) {
     console.error("Failed to update fee structure:", error)
     const message = error instanceof Error ? error.message : "Failed to update fee structure"
     return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const identifier = searchParams.get("id")
+
+    if (!identifier) {
+      return NextResponse.json({ error: "Fee structure ID is required" }, { status: 400 })
+    }
+
+    const deleted = await deleteFeeStructureRecord(identifier)
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Fee structure not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Failed to delete fee structure:", error)
+    return NextResponse.json({ error: "Failed to delete fee structure" }, { status: 500 })
   }
 }

--- a/app/api/payments/fee-structure/send/route.ts
+++ b/app/api/payments/fee-structure/send/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { listFeeStructures, listStudentRecords, recordFeeStructureDelivery } from "@/lib/database"
+import { sanitizeInput } from "@/lib/security"
+
+export const runtime = "nodejs"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const feeId = typeof body.feeId === "string" ? sanitizeInput(body.feeId) : ""
+    const className = typeof body.className === "string" ? sanitizeInput(body.className) : ""
+    const parentEmail = typeof body.parentEmail === "string" ? sanitizeInput(body.parentEmail) : ""
+    const parentName = typeof body.parentName === "string" ? sanitizeInput(body.parentName) : ""
+    const studentName = typeof body.studentName === "string" ? sanitizeInput(body.studentName) : ""
+    const sentBy = typeof body.sentBy === "string" ? sanitizeInput(body.sentBy) : ""
+
+    if (!feeId || !className || !parentEmail || !parentName || !studentName || !sentBy) {
+      return NextResponse.json({ error: "Incomplete payload" }, { status: 400 })
+    }
+
+    const feeStructures = await listFeeStructures()
+    const fee = feeStructures.find(
+      (entry) => entry.id === feeId || entry.className.toLowerCase() === className.toLowerCase(),
+    )
+
+    if (!fee) {
+      return NextResponse.json({ error: "Fee structure not found" }, { status: 404 })
+    }
+
+    const students = await listStudentRecords()
+    const matchingStudent = students.find(
+      (student) =>
+        student.class.toLowerCase() === className.toLowerCase() &&
+        student.parentEmail.toLowerCase() === parentEmail.toLowerCase(),
+    )
+
+    if (!matchingStudent) {
+      return NextResponse.json({ error: "Parent is not linked to the specified class" }, { status: 400 })
+    }
+
+    const delivery = await recordFeeStructureDelivery({
+      feeId: fee.id,
+      className: fee.className,
+      parentEmail,
+      parentName,
+      studentName: matchingStudent.name ?? studentName,
+      sentBy,
+      breakdown: {
+        tuition: fee.tuition,
+        development: fee.development,
+        exam: fee.exam,
+        sports: fee.sports,
+        library: fee.library,
+        total: fee.total,
+      },
+      message: typeof body.message === "string" ? sanitizeInput(body.message) : undefined,
+    })
+
+    return NextResponse.json({ delivery, message: "Fee structure sent successfully" })
+  } catch (error) {
+    console.error("Failed to send fee structure:", error)
+    const message = error instanceof Error ? error.message : "Failed to send fee structure"
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}


### PR DESCRIPTION
## Summary
- connect the teacher dashboard to real assignments with API-backed creation, uploads, and safe attachment downloads
- persist study materials in the database manager with teacher/student filtering plus guarded deletion and download helpers
- expand the accountant dashboard to edit/delete fee structures and send class-specific fees to parents, including new API routes and storage for delivery records
- restrict noticeboard actions to the original author and add supporting database helpers for fee communications

## Testing
- pnpm lint *(fails: existing repository lint violations remain – see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68d0afd543f48327befc2f1fbbb4f0ce