### PR TITLE
Add tutorials and enhance librarian/accountant dashboards

### DIFF
--- a/components/admin-approval-dashboard.tsx
+++ b/components/admin-approval-dashboard.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
-import { Download, Check, X, Calendar, Clock, User, BookOpen } from "lucide-react"
+import { Download, Check, X, Calendar, Clock, User, BookOpen, Youtube } from "lucide-react"
 import { safeStorage } from "@/lib/safe-storage"
 
 interface StudentReportCard {
@@ -197,8 +197,21 @@ export function AdminApprovalDashboard() {
   return (
     <div className="space-y-6">
       <div className="bg-gradient-to-r from-[#2d682d] to-[#b29032] text-white p-6 rounded-lg">
-        <h1 className="text-2xl font-bold">Report Card Approval Center</h1>
-        <p className="text-white/90">Review and approve student report cards submitted by teachers</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Report Card Approval Center</h1>
+            <p className="text-white/90">Review and approve student report cards submitted by teachers</p>
+          </div>
+          <a
+            href="https://www.youtube.com/watch?v=ysz5S6PUM-U"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 self-start rounded-md bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+          >
+            <Youtube className="h-4 w-4" />
+            Tutorial
+          </a>
+        </div>
       </div>
 
       <Card>

--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -17,7 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { BookOpen, Calendar, FileText, User, Clock, Trophy, Upload, CheckCircle } from "lucide-react"
+import { BookOpen, Calendar, FileText, User, Clock, Trophy, Upload, CheckCircle, Youtube } from "lucide-react"
 import { StudyMaterials } from "@/components/study-materials"
 import { Noticeboard } from "@/components/noticeboard"
 import { dbManager } from "@/lib/database-manager"
@@ -320,12 +320,21 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
     <div className="space-y-6">
       {/* Header */}
       <div className="bg-gradient-to-r from-[#2d682d] to-[#b29032] text-white p-6 rounded-lg">
-        <div className="flex justify-between items-start">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h1 className="text-2xl font-bold">Welcome, {studentProfile.name}</h1>
             <p className="text-green-100">Student Portal - {student.class} - VEA 2025</p>
             <p className="text-sm text-green-200">Admission No: {student.admissionNumber}</p>
           </div>
+          <a
+            href="https://www.youtube.com/watch?v=1FJD7jZqZEk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 self-start rounded-md bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+          >
+            <Youtube className="h-4 w-4" />
+            Tutorial
+          </a>
         </div>
       </div>
 

--- a/components/super-admin-dashboard.tsx
+++ b/components/super-admin-dashboard.tsx
@@ -73,6 +73,7 @@ import {
   TrendingUp,
   Users,
   DollarSign,
+  Youtube,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -960,6 +961,15 @@ export default function SuperAdminDashboard() {
           <p className="text-gray-600">Holistic control for every panel within the VEA portal</p>
         </div>
         <div className="flex flex-wrap gap-2">
+          <a
+            href="https://www.youtube.com/watch?v=04854XqcfCY"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-[#2d682d]/20 bg-[#2d682d]/10 px-4 py-2 text-sm font-medium text-[#1f4a1f] transition hover:bg-[#2d682d]/20"
+          >
+            <Youtube className="h-4 w-4" />
+            Tutorial
+          </a>
           <Button variant="outline" onClick={handleRefresh} disabled={isRefreshing}>
             <RefreshCw className={cn("mr-2 h-4 w-4", isRefreshing && "animate-spin")} />
             Refresh Data

--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -17,7 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { BookOpen, Users, FileText, GraduationCap, Clock, User, Plus, Save, Loader2 } from "lucide-react"
+import { BookOpen, Users, FileText, GraduationCap, Clock, User, Plus, Save, Loader2, Youtube } from "lucide-react"
 import { StudyMaterials } from "@/components/study-materials"
 import { Noticeboard } from "@/components/noticeboard"
 import { InternalMessaging } from "@/components/internal-messaging"
@@ -745,10 +745,23 @@ export function TeacherDashboard({ teacher }: TeacherDashboardProps) {
     <div className="space-y-6">
       {/* Header */}
       <div className="bg-gradient-to-r from-[#2d682d] to-[#b29032] text-white p-6 rounded-lg">
-        <h1 className="text-2xl font-bold">Welcome, {teacher.name}</h1>
-        <div className="text-green-100 text-sm sm:text-base space-y-1">
-          <p>Subjects: {subjectSummary}</p>
-          <p>Classes: {classSummary}</p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Welcome, {teacher.name}</h1>
+            <div className="text-green-100 text-sm sm:text-base space-y-1">
+              <p>Subjects: {subjectSummary}</p>
+              <p>Classes: {classSummary}</p>
+            </div>
+          </div>
+          <a
+            href="https://www.youtube.com/watch?v=HkyVTxH2fIM"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 self-start rounded-md bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+          >
+            <Youtube className="h-4 w-4" />
+            Tutorial
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add tutorial call-to-action links with YouTube icons across the super admin, student, teacher, librarian, and accountant experiences
- overhaul the librarian portal with modal forms for adding/editing books, detailed inventory dialogs, and the ability to delete records cleanly
- expand the accountant portal with manual payment recording, local storage integration, searchable payment lists, and offline receipt generation support

## Testing
- pnpm lint *(fails: repository contains pre-existing lint errors and console usage warnings)*
- pnpm type-check *(fails: project already ships with TypeScript errors in components/financial-reports.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c1ce4c14832789f0b96746acd01b