### PR TITLE
Enhance promotion, calendar, and payment integrations

### DIFF
--- a/components/school-calendar-viewer.tsx
+++ b/components/school-calendar-viewer.tsx
@@ -155,8 +155,8 @@ export function SchoolCalendarViewer({
       </CardContent>
 
       <Dialog open={isOpen && canPreview} onOpenChange={setIsOpen}>
-        <DialogContent className="max-w-4xl max-h-[85vh] overflow-hidden p-0 sm:max-w-5xl">
-          <div className="flex max-h-[85vh] flex-col">
+        <DialogContent className="max-w-4xl max-h-[90vh] p-0 sm:max-w-5xl">
+          <div className="flex max-h-[90vh] flex-col overflow-hidden">
             <DialogHeader className="sr-only">
               <DialogTitle>{branding.schoolName ?? "Victory Educational Academy"} School Calendar</DialogTitle>
               <DialogDescription>Published school calendar view</DialogDescription>

--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -22,6 +22,7 @@ import { StudyMaterials } from "@/components/study-materials"
 import { Noticeboard } from "@/components/noticeboard"
 import { TutorialLink } from "@/components/tutorial-link"
 import { ExamScheduleOverview } from "@/components/exam-schedule-overview"
+import { SchoolCalendarViewer } from "@/components/school-calendar-viewer"
 import { dbManager } from "@/lib/database-manager"
 import { logger } from "@/lib/logger"
 
@@ -436,20 +437,21 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
               </CardContent>
             </Card>
 
-            <ExamScheduleOverview
-              role="student"
-              title="Upcoming Exams"
-              description="Plan ahead with the latest exam schedule for your class."
-              classNames={[studentProfile.class]}
-              className="h-full"
-              emptyState="No upcoming exams scheduled for your class yet."
-              limit={4}
-            />
-          </div>
+          <ExamScheduleOverview
+            role="student"
+            title="Upcoming Exams"
+            description="Plan ahead with the latest exam schedule for your class."
+            classNames={[studentProfile.class]}
+            className="h-full"
+            emptyState="No upcoming exams scheduled for your class yet."
+            limit={4}
+          />
+          <SchoolCalendarViewer role="student" className="md:col-span-2 xl:col-span-3" />
+        </div>
 
-          <div className="mt-8">
-            <Noticeboard userRole="student" userName={studentProfile.name} />
-          </div>
+        <div className="mt-8">
+          <Noticeboard userRole="student" userName={studentProfile.name} />
+        </div>
         </TabsContent>
 
         <TabsContent value="subjects" className="space-y-4">

--- a/lib/safe-storage.ts
+++ b/lib/safe-storage.ts
@@ -27,41 +27,46 @@ function resolveStorage(kind: StorageKind): Storage | null {
 }
 
 function createSafeStorage(kind: StorageKind): SafeStorage {
+  const memoryStore = new Map<string, string>()
+
   return {
     getItem: (key: string) => {
       const storage = resolveStorage(kind)
       if (!storage) {
-        return null
+        return memoryStore.get(key) ?? null
       }
 
       try {
-        return storage.getItem(key)
+        const value = storage.getItem(key)
+        return value ?? memoryStore.get(key) ?? null
       } catch (error) {
-        return null
+        return memoryStore.get(key) ?? null
       }
     },
     setItem: (key: string, value: string) => {
       const storage = resolveStorage(kind)
       if (!storage) {
+        memoryStore.set(key, value)
         return
       }
 
       try {
         storage.setItem(key, value)
       } catch (error) {
-        // Ignore storage quota errors
+        memoryStore.set(key, value)
       }
     },
     removeItem: (key: string) => {
       const storage = resolveStorage(kind)
       if (!storage) {
+        memoryStore.delete(key)
         return
       }
 
       try {
         storage.removeItem(key)
       } catch (error) {
-        // Ignore removal issues
+        memoryStore.delete(key)
       }
     },
   }


### PR DESCRIPTION
## Summary
- normalize and persist student promotion analyses with live data refresh and batch updates
- add scrollable published calendar preview and surface calendar card on the student dashboard
- merge accountant entries into super-admin payment analytics with cached refreshes

## Testing
- `pnpm lint` *(fails: existing repo lint violations for console usage, any types, and restricted globals)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e8cabf88327b177ba183734df5b