### PR TITLE
Implement class timetable management UI and sharing

### DIFF
--- a/app/api/timetable/publish/route.ts
+++ b/app/api/timetable/publish/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { getTimetableSlots } from "@/lib/database"
+import { logger } from "@/lib/logger"
+import { publishNotification } from "@/lib/realtime-hub"
+import { mapTimetableRecordToResponse } from "@/lib/timetable"
+
+export const runtime = "nodejs"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as { className?: unknown }
+    const className = typeof body.className === "string" ? body.className.trim() : ""
+
+    if (!className) {
+      return NextResponse.json({ error: "Class name is required" }, { status: 400 })
+    }
+
+    const slots = await getTimetableSlots({ className })
+    const timetable = slots.map(mapTimetableRecordToResponse)
+
+    publishNotification({
+      id: typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `notification_${Date.now()}`,
+      title: `Timetable updated for ${className}`,
+      body: "The class timetable has been refreshed. Please review the latest schedule.",
+      category: "timetable",
+      createdAt: new Date().toISOString(),
+      targetUserIds: [],
+      targetRoles: ["student", "teacher", "parent"],
+      meta: {
+        className,
+        timetable,
+      },
+    })
+
+    return NextResponse.json({ success: true, timetable })
+  } catch (error) {
+    logger.error("Failed to publish timetable update", { error })
+    return NextResponse.json({ error: "Failed to publish timetable update" }, { status: 500 })
+  }
+}

--- a/components/timetable-weekly-view.tsx
+++ b/components/timetable-weekly-view.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useEffect, useMemo, useState } from "react"
+
+import { DEFAULT_TIMETABLE_PERIODS, DAY_ORDER, formatTimetablePeriodRange, normaliseTimeRangeLabel, type TimetableSlotViewModel } from "@/lib/timetable"
+
+export type TimetableWeeklyViewSlot = Pick<
+  TimetableSlotViewModel,
+  "id" | "day" | "time" | "subject" | "teacher" | "location"
+>
+
+interface TimetableWeeklyViewProps {
+  slots: TimetableWeeklyViewSlot[]
+  renderDetails?: (slot: TimetableWeeklyViewSlot) => ReactNode
+  emptyMessage?: string
+  initialDay?: string
+}
+
+const defaultRenderDetails = (slot: TimetableWeeklyViewSlot) => {
+  const details: string[] = []
+  if (slot.teacher && slot.teacher.trim().length > 0) {
+    details.push(`Teacher: ${slot.teacher}`)
+  }
+  if (slot.location && slot.location.trim().length > 0) {
+    details.push(`Location: ${slot.location}`)
+  }
+
+  if (details.length === 0) {
+    return <p className="text-sm text-emerald-700/70">Teacher and venue will be shared soon.</p>
+  }
+
+  return <p className="text-sm text-emerald-700/80">{details.join(" • ")}</p>
+}
+
+export function TimetableWeeklyView({ slots, renderDetails = defaultRenderDetails, emptyMessage, initialDay }: TimetableWeeklyViewProps) {
+  const dayMaps = useMemo(() => {
+    const map = new Map<string, Map<string, TimetableWeeklyViewSlot>>()
+    DAY_ORDER.forEach((day) => {
+      map.set(day, new Map())
+    })
+
+    slots.forEach((slot) => {
+      const normalizedDay =
+        DAY_ORDER.find((day) => day.toLowerCase() === slot.day.toLowerCase()) ?? slot.day
+      const dayMap = map.get(normalizedDay) ?? new Map<string, TimetableWeeklyViewSlot>()
+      dayMap.set(normaliseTimeRangeLabel(slot.time), slot)
+      map.set(normalizedDay, dayMap)
+    })
+
+    return map
+  }, [slots])
+
+  const resolveInitialDay = () => {
+    if (initialDay) {
+      const normalized = DAY_ORDER.find((day) => day.toLowerCase() === initialDay.toLowerCase())
+      if (normalized) {
+        return normalized
+      }
+    }
+
+    const firstDayWithSlots = DAY_ORDER.find((day) => (dayMaps.get(day)?.size ?? 0) > 0)
+    return firstDayWithSlots ?? DAY_ORDER[0]
+  }
+
+  const [activeDay, setActiveDay] = useState<string>(() => resolveInitialDay())
+
+  useEffect(() => {
+    if (!DAY_ORDER.includes(activeDay)) {
+      setActiveDay(DAY_ORDER[0])
+      return
+    }
+
+    const currentDaySlots = dayMaps.get(activeDay)
+    if ((currentDaySlots?.size ?? 0) > 0) {
+      return
+    }
+
+    const firstDayWithSlots = DAY_ORDER.find((day) => (dayMaps.get(day)?.size ?? 0) > 0)
+    if (firstDayWithSlots) {
+      setActiveDay(firstDayWithSlots)
+    }
+  }, [activeDay, dayMaps])
+
+  const activeDayMap = dayMaps.get(activeDay) ?? new Map<string, TimetableWeeklyViewSlot>()
+  const hasAnySlot = slots.length > 0
+  const hasScheduledPeriods = DEFAULT_TIMETABLE_PERIODS.some((period) => {
+    if (period.kind === "break") {
+      return false
+    }
+
+    const range = formatTimetablePeriodRange(period)
+    const slot = activeDayMap.get(range)
+    return Boolean(slot && slot.subject.trim().length > 0)
+  })
+
+  if (!hasAnySlot && emptyMessage) {
+    return (
+      <div className="rounded-3xl border border-emerald-100 bg-white/80 p-6 text-center shadow-sm">
+        <p className="text-sm text-emerald-700/80">{emptyMessage}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-emerald-100 bg-white/85 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-emerald-100 bg-gradient-to-r from-emerald-500/10 via-white to-emerald-500/10 px-5 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700/70">Selected day</p>
+            <h3 className="text-xl font-semibold text-emerald-900">{activeDay}</h3>
+            {!hasScheduledPeriods ? (
+              <p className="text-xs text-emerald-700/70">All periods are currently free for this day.</p>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {DAY_ORDER.map((day) => {
+              const isActive = day === activeDay
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={() => setActiveDay(day)}
+                  className={`rounded-full px-3 py-1 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 ${
+                    isActive
+                      ? "bg-white text-emerald-900 shadow"
+                      : "bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/20"
+                  }`}
+                >
+                  {day.slice(0, 3)}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+        <div className="space-y-3 p-5">
+          {DEFAULT_TIMETABLE_PERIODS.map((period) => {
+            const range = formatTimetablePeriodRange(period)
+
+            if (period.kind === "break") {
+              return (
+                <div
+                  key={period.id}
+                  className="relative overflow-hidden rounded-3xl border border-amber-200/70 bg-gradient-to-r from-amber-50 via-white to-amber-100 p-5"
+                >
+                  <div className="absolute inset-x-0 top-0 h-1 bg-amber-300/70" />
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                        {period.label}
+                      </span>
+                      <h4 className="text-lg font-semibold text-amber-900">10-minute Break</h4>
+                      <p className="text-sm text-amber-700/80">Time to refresh and prepare for the next lessons.</p>
+                    </div>
+                    <div className="flex flex-col items-end gap-2 text-right">
+                      <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-amber-700 shadow-inner">
+                        {range}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )
+            }
+
+            const slot = activeDayMap.get(range)
+            const hasSlot = Boolean(slot && slot.subject.trim().length > 0)
+
+            return (
+              <div
+                key={period.id}
+                className="relative overflow-hidden rounded-3xl border border-emerald-200/70 bg-gradient-to-br from-emerald-50 via-white to-emerald-100 p-6"
+              >
+                <div className="absolute inset-x-0 top-0 h-1 bg-emerald-400/70" />
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                      {period.label}
+                    </span>
+                    <h4 className="text-lg font-semibold text-emerald-900">
+                      {hasSlot ? slot?.subject || "Subject not set" : "Free period"}
+                    </h4>
+                    {hasSlot && slot ? (
+                      renderDetails(slot)
+                    ) : (
+                      <p className="text-sm text-emerald-700/70">No class scheduled yet. Enjoy a study moment or prepare ahead.</p>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-end gap-2 text-right">
+                    <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-emerald-700 shadow-inner">
+                      {range}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/timetable.ts
+++ b/lib/timetable.ts
@@ -1,0 +1,213 @@
+export type TimetablePeriodKind = "class" | "break"
+
+export interface TimetablePeriodDefinition {
+  id: string
+  label: string
+  startTime: string
+  endTime: string
+  kind: TimetablePeriodKind
+}
+
+export interface TimetableSlotViewModel {
+  id: string
+  className?: string
+  day: string
+  time: string
+  startTime: string
+  endTime: string
+  subject: string
+  teacher: string
+  location: string | null
+}
+
+export interface TimetableNotificationPayload extends TimetableSlotViewModel {}
+
+export const DAY_ORDER: readonly string[] = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+
+function minutesToTime(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`
+}
+
+export function to24HourTime(time: string): string {
+  const trimmed = time.trim()
+  const match = trimmed.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)?$/i)
+
+  if (!match) {
+    return trimmed
+  }
+
+  let hour = Number(match[1])
+  const minute = match[2]
+  const meridiem = match[3]?.toUpperCase()
+
+  if (meridiem === "PM" && hour !== 12) {
+    hour += 12
+  }
+
+  if (meridiem === "AM" && hour === 12) {
+    hour = 0
+  }
+
+  return `${hour.toString().padStart(2, "0")}:${minute}`
+}
+
+export function to12HourTime(time: string): string {
+  const [rawHour, rawMinute = "00"] = time.split(":")
+  let hour = Number(rawHour)
+  const minute = rawMinute.padStart(2, "0")
+  const meridiem = hour >= 12 ? "PM" : "AM"
+  hour = hour % 12 || 12
+  return `${hour}:${minute} ${meridiem}`
+}
+
+export function parseTimeRangeLabel(range: string): { start: string; end: string } {
+  if (typeof range !== "string" || range.trim().length === 0) {
+    return { start: "08:00", end: "08:40" }
+  }
+
+  const [rawStart, rawEnd] = range.split("-").map((value) => value.trim())
+  return {
+    start: to24HourTime(rawStart ?? "08:00"),
+    end: to24HourTime(rawEnd ?? "08:40"),
+  }
+}
+
+export function formatTimeRange(start: string, end: string): string {
+  return `${to12HourTime(start)} - ${to12HourTime(end)}`
+}
+
+export function normaliseTimeRangeLabel(range: string): string {
+  const { start, end } = parseTimeRangeLabel(range)
+  return formatTimeRange(start, end)
+}
+
+function createDefaultPeriods(): TimetablePeriodDefinition[] {
+  const periods: TimetablePeriodDefinition[] = []
+  let currentMinutes = 8 * 60 // 8:00 AM
+
+  for (let index = 1; index <= 3; index += 1) {
+    const start = minutesToTime(currentMinutes)
+    const end = minutesToTime(currentMinutes + 40)
+    periods.push({
+      id: `period-${index}`,
+      label: `Period ${index}`,
+      startTime: start,
+      endTime: end,
+      kind: "class",
+    })
+    currentMinutes += 40
+  }
+
+  const breakStart = minutesToTime(currentMinutes)
+  currentMinutes += 10
+  const breakEnd = minutesToTime(currentMinutes)
+
+  periods.push({
+    id: "break",
+    label: "Break",
+    startTime: breakStart,
+    endTime: breakEnd,
+    kind: "break",
+  })
+
+  for (let index = 4; index <= 7; index += 1) {
+    const start = minutesToTime(currentMinutes)
+    const end = minutesToTime(currentMinutes + 40)
+    periods.push({
+      id: `period-${index}`,
+      label: `Period ${index}`,
+      startTime: start,
+      endTime: end,
+      kind: "class",
+    })
+    currentMinutes += 40
+  }
+
+  return periods
+}
+
+export const DEFAULT_TIMETABLE_PERIODS: readonly TimetablePeriodDefinition[] = createDefaultPeriods()
+
+export const CLASS_TIMETABLE_PERIODS = DEFAULT_TIMETABLE_PERIODS.filter((period) => period.kind === "class")
+
+export function formatTimetablePeriodRange(period: TimetablePeriodDefinition): string {
+  return formatTimeRange(period.startTime, period.endTime)
+}
+
+export function mapTimetableRecordToResponse(slot: {
+  id: string
+  className: string
+  day: string
+  startTime: string
+  endTime: string
+  subject: string
+  teacher: string
+  location?: string | null
+}): TimetableSlotViewModel {
+  const time = formatTimeRange(slot.startTime, slot.endTime)
+  return {
+    id: slot.id,
+    className: slot.className,
+    day: slot.day,
+    subject: slot.subject,
+    teacher: slot.teacher,
+    location: slot.location ?? null,
+    startTime: slot.startTime,
+    endTime: slot.endTime,
+    time,
+  }
+}
+
+export function normalizeTimetableSlot(slot: unknown): TimetableSlotViewModel | null {
+  if (!slot || typeof slot !== "object") {
+    return null
+  }
+
+  const record = slot as Record<string, unknown>
+  const id = typeof record.id === "string" ? record.id : String(record.id ?? `slot_${Date.now()}`)
+  const day = typeof record.day === "string" ? record.day : "Monday"
+  const className = typeof record.className === "string" ? record.className : undefined
+
+  const rawTime =
+    typeof record.time === "string"
+      ? record.time
+      : `${typeof record.startTime === "string" ? record.startTime : "08:00"} - ${
+          typeof record.endTime === "string" ? record.endTime : "08:40"
+        }`
+
+  const { start, end } = parseTimeRangeLabel(rawTime)
+  const subject = typeof record.subject === "string" ? record.subject : ""
+  const teacher = typeof record.teacher === "string" ? record.teacher : ""
+  const location = typeof record.location === "string" ? record.location : null
+
+  return {
+    id,
+    day,
+    className,
+    subject,
+    teacher,
+    location,
+    startTime: start,
+    endTime: end,
+    time: formatTimeRange(start, end),
+  }
+}
+
+export function normalizeTimetableCollection(value: unknown): TimetableSlotViewModel[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => normalizeTimetableSlot(entry))
+    .filter((slot): slot is TimetableSlotViewModel => slot !== null)
+}
+
+export function minutesFromTimeLabel(label: string): number {
+  const { start } = parseTimeRangeLabel(label)
+  const [hour, minute] = start.split(":").map(Number)
+  return hour * 60 + minute
+}
+


### PR DESCRIPTION
## Summary
- add shared timetable utilities for 40-minute periods, normalization and formatting helpers
- refresh the admin timetable manager with class selection, gradient cards and publish workflow
- render the new weekly timetable view on student, teacher and parent dashboards with realtime publish endpoint

## Testing
- pnpm lint *(fails: existing lint violations across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d366ae9a6483279dece9a8dd88c6a3