### PR TITLE
Enhance admin previews with enriched report card metadata

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -189,6 +189,7 @@ export interface ReportCardRecord extends CollectionRecord {
   subjects: ReportCardSubjectRecord[]
   classTeacherRemark?: string | null
   headTeacherRemark?: string | null
+  metadata?: Record<string, unknown> | null
 }
 
 export interface ReportCardColumnRecord {
@@ -589,9 +590,10 @@ function createDefaultUsers(): StoredUser[] {
       role: "parent",
       password: "Parent2025!",
       metadata: {
-        linkedStudentId: "user_student",
+        linkedStudentId: "student_john_doe",
+        phone: "+2348012345670",
       },
-      studentIds: ["user_student"],
+      studentIds: ["student_john_doe"],
     },
     {
       id: "user_librarian",
@@ -1954,6 +1956,7 @@ export async function upsertReportCardRecord(payload: UpsertReportCardPayload): 
       subjects: normalizedSubjects,
       classTeacherRemark: payload.classTeacherRemark ?? existing.classTeacherRemark ?? null,
       headTeacherRemark: payload.headTeacherRemark ?? existing.headTeacherRemark ?? null,
+      metadata: payload.metadata ?? existing.metadata ?? null,
       updatedAt: timestamp,
     }
     reportCards[findIndex] = updated
@@ -1971,6 +1974,7 @@ export async function upsertReportCardRecord(payload: UpsertReportCardPayload): 
     subjects: normalizedSubjects,
     classTeacherRemark: payload.classTeacherRemark ?? null,
     headTeacherRemark: payload.headTeacherRemark ?? null,
+    metadata: payload.metadata ?? null,
     createdAt: timestamp,
     updatedAt: timestamp,
   }

--- a/lib/report-card-transformers.ts
+++ b/lib/report-card-transformers.ts
@@ -2,6 +2,28 @@ import type { ReportCardRecord, ReportCardSubjectRecord } from "@/lib/database"
 import { deriveGradeFromScore } from "@/lib/grade-utils"
 import type { RawReportCardData } from "@/lib/report-card-types"
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+const extractRawFromMetadata = (metadata: unknown): RawReportCardData | null => {
+  if (!isRecord(metadata)) {
+    return null
+  }
+
+  const container = metadata as Record<string, unknown>
+  const candidate =
+    container.enhancedReportCard ??
+    container.enhancedReport ??
+    container.rawReportCard ??
+    container.reportCard
+
+  if (isRecord(candidate)) {
+    return candidate as RawReportCardData
+  }
+
+  return null
+}
+
 const normaliseSubject = (subject: ReportCardSubjectRecord) => {
   const ca1 = Number.isFinite(subject.ca1) ? subject.ca1 : 0
   const ca2 = Number.isFinite(subject.ca2) ? subject.ca2 : 0
@@ -33,7 +55,14 @@ export const mapReportCardRecordToRaw = (record: ReportCardRecord): RawReportCar
   const averageScore =
     totalMarksObtainable > 0 ? Number(((totalMarksObtained / totalMarksObtainable) * 100).toFixed(2)) : 0
 
-  return {
+  const baseSummary = {
+    totalMarksObtainable,
+    totalMarksObtained,
+    averageScore,
+    grade: deriveGradeFromScore(averageScore),
+  }
+
+  const base: RawReportCardData = {
     student: {
       id: record.studentId,
       name: record.studentName,
@@ -43,15 +72,11 @@ export const mapReportCardRecordToRaw = (record: ReportCardRecord): RawReportCar
       session: record.session,
     },
     subjects,
-    summary: {
-      totalMarksObtainable,
-      totalMarksObtained: totalMarksObtained,
-      averageScore,
-      grade: deriveGradeFromScore(averageScore),
-    },
+    summary: baseSummary,
     totalObtainable: totalMarksObtainable,
     totalObtained: totalMarksObtained,
     average: averageScore,
+    position: baseSummary.position,
     affectiveDomain: {},
     psychomotorDomain: {},
     classTeacherRemarks: record.classTeacherRemark ?? undefined,
@@ -59,5 +84,54 @@ export const mapReportCardRecordToRaw = (record: ReportCardRecord): RawReportCar
       classTeacher: record.classTeacherRemark ?? undefined,
       headTeacher: record.headTeacherRemark ?? undefined,
     },
+  }
+
+  const metadataRaw = extractRawFromMetadata(record.metadata)
+  if (!metadataRaw) {
+    return base
+  }
+
+  const metadataStudent = isRecord(metadataRaw.student) ? metadataRaw.student : {}
+  const metadataSummary = metadataRaw.summary
+    ? { ...baseSummary, ...metadataRaw.summary }
+    : baseSummary
+  const metadataSubjects = Array.isArray(metadataRaw.subjects) && metadataRaw.subjects.length > 0
+    ? metadataRaw.subjects
+    : subjects
+  const mergedClassTeacherRemark =
+    metadataRaw.classTeacherRemarks ?? metadataRaw.remarks?.classTeacher ?? base.classTeacherRemarks
+
+  return {
+    ...base,
+    ...metadataRaw,
+    student: {
+      ...base.student,
+      ...metadataStudent,
+      id: metadataStudent.id ? String(metadataStudent.id) : base.student.id,
+      name: metadataStudent.name ?? base.student.name,
+      admissionNumber: metadataStudent.admissionNumber ?? base.student.admissionNumber,
+      class: metadataStudent.class ?? base.student.class,
+      term: metadataStudent.term ?? base.student.term,
+      session: metadataStudent.session ?? base.student.session,
+      numberInClass: metadataStudent.numberInClass ?? base.student.numberInClass,
+      status: metadataStudent.status ?? base.student.status,
+    },
+    subjects: metadataSubjects,
+    summary: metadataSummary,
+    totalObtainable:
+      metadataRaw.totalObtainable ?? metadataSummary.totalMarksObtainable ?? base.totalObtainable,
+    totalObtained: metadataRaw.totalObtained ?? metadataSummary.totalMarksObtained ?? base.totalObtained,
+    average: metadataRaw.average ?? metadataSummary.averageScore ?? base.average,
+    position: metadataRaw.position ?? metadataSummary.position ?? base.position,
+    classTeacherRemarks: mergedClassTeacherRemark,
+    remarks: {
+      classTeacher: metadataRaw.remarks?.classTeacher ?? mergedClassTeacherRemark,
+      headTeacher: metadataRaw.remarks?.headTeacher ?? base.remarks?.headTeacher,
+    },
+    affectiveDomain: metadataRaw.affectiveDomain ?? base.affectiveDomain,
+    psychomotorDomain: metadataRaw.psychomotorDomain ?? base.psychomotorDomain,
+    attendance: metadataRaw.attendance ?? base.attendance,
+    termInfo: metadataRaw.termInfo ?? base.termInfo,
+    fees: metadataRaw.fees ?? base.fees,
   }
 }


### PR DESCRIPTION
## Summary
- seed the teacher dashboard with supplemental sample subjects and a shared preview builder so stored report cards carry complete enhanced payloads and streamline preview handling
- extend report card records with optional metadata when upserting so saved data retains enhanced snapshots for downstream reviewers
- make the transformer merge any enhanced metadata when building raw report cards so admin and super admin previews load the full design

## Testing
- pnpm lint *(fails: repository already has numerous lint warnings and errors)*
- pnpm type-check *(fails: repository already has extensive existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d38156df048327bc0355a69d8ee6b1