### PR TITLE
Use uploaded branding across portal surfaces

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,7 @@ import { logger } from "@/lib/logger"
 import { normalizeTimetableCollection } from "@/lib/timetable"
 import { toast } from "@/hooks/use-toast"
 import type { Viewport } from "next"
+import Image from "next/image"
 import { SchoolCalendarManager } from "@/components/admin/school-calendar-manager"
 import { SchoolCalendarViewer } from "@/components/school-calendar-viewer"
 import { TimetableWeeklyView, type TimetableWeeklyViewSlot } from "@/components/timetable-weekly-view"
@@ -58,6 +59,7 @@ import {
   type ReportCardAccessRecord,
   syncReportCardAccess,
 } from "@/lib/report-card-access"
+import { useBranding } from "@/hooks/use-branding"
 
 export const dynamic = "force-dynamic"
 export const viewport: Viewport = {
@@ -216,6 +218,12 @@ const FALLBACK_ACCOUNTS: FallbackAccount[] = [
 ]
 
 export default function HomePage() {
+  const branding = useBranding()
+  const resolvedLogo = branding.logoUrl
+  const resolvedSchoolName = branding.schoolName
+  const portalDescription = resolvedSchoolName
+    ? `${resolvedSchoolName} School Management Portal`
+    : "School Management Portal"
   const [currentUser, setCurrentUser] = useState<User | null>(null)
   const [loginForm, setLoginForm] = useState({ email: "", password: "", role: "parent" as UserRole })
   const [registerForm, setRegisterForm] = useState({
@@ -571,10 +579,20 @@ export default function HomePage() {
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <div className="flex items-center justify-center mb-4">
-            <GraduationCap className="h-12 w-12 text-[#2d682d]" />
+            {resolvedLogo ? (
+              <Image
+                src={resolvedLogo}
+                alt={`${resolvedSchoolName} logo`}
+                width={48}
+                height={48}
+                className="h-12 w-12 object-contain rounded-md shadow-sm"
+              />
+            ) : (
+              <GraduationCap className="h-12 w-12 text-[#2d682d]" />
+            )}
           </div>
-          <h1 className="text-3xl font-bold text-[#2d682d] mb-2">VEA 2025</h1>
-          <p className="text-[#b29032]">School Management Portal</p>
+          <h1 className="text-3xl font-bold text-[#2d682d] mb-2">{resolvedSchoolName}</h1>
+          <p className="text-[#b29032]">{portalDescription}</p>
         </div>
 
         <Card className="border-[#2d682d]/20 bg-white/95 backdrop-blur shadow-xl">
@@ -933,6 +951,9 @@ export default function HomePage() {
 }
 
 function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
+  const branding = useBranding()
+  const resolvedLogo = branding.logoUrl
+  const resolvedSchoolName = branding.schoolName
   const [teacherAssignments, setTeacherAssignments] = useState({
     classes:
       user.role === "teacher"
@@ -1090,9 +1111,19 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         <div className="max-w-7xl mx-auto px-4 sm:px:6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center gap-3">
-              <GraduationCap className="h-8 w-8 text-[#b29032]" />
+              {resolvedLogo ? (
+                <Image
+                  src={resolvedLogo}
+                  alt={`${resolvedSchoolName} logo`}
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 object-contain rounded-md bg-white/10 p-1"
+                />
+              ) : (
+                <GraduationCap className="h-8 w-8 text-[#b29032]" />
+              )}
               <div>
-                <h1 className="text-xl font-bold">VEA 2025</h1>
+                <h1 className="text-xl font-bold">{resolvedSchoolName}</h1>
                 <p className="text-sm text-green-200">{getRoleDisplayName(user.role)} Portal</p>
               </div>
             </div>

--- a/components/accountant-dashboard.tsx
+++ b/components/accountant-dashboard.tsx
@@ -885,7 +885,7 @@ export function AccountantDashboard({ accountant }: AccountantDashboardProps) {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h1 className="text-2xl font-bold">Welcome, {accountant.name}</h1>
-            <p className="text-green-100">Financial Management - VEA 2025</p>
+            <p className="text-green-100">Financial Management - {resolvedSchoolName}</p>
           </div>
           <TutorialLink href="https://www.youtube.com/watch?v=6Dh-RL__uN4" variant="inverse" />
         </div>

--- a/components/exam-management.tsx
+++ b/components/exam-management.tsx
@@ -14,6 +14,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
+import { useBranding } from "@/hooks/use-branding"
 import { dbManager } from "@/lib/database-manager"
 import {
   CONTINUOUS_ASSESSMENT_MAXIMUMS,
@@ -150,6 +151,9 @@ const resultStatusBadgeVariant = (status: ExamResult["status"]) => {
 }
 
 export default function ExamManagement() {
+  const branding = useBranding()
+  const resolvedLogo = branding.logoUrl
+  const resolvedSchoolName = branding.schoolName
   const { toast } = useToast()
   const [activeTab, setActiveTab] = useState("upcoming")
   const [classOptions, setClassOptions] = useState<Array<{ value: string; label: string }>>([])
@@ -759,6 +763,19 @@ export default function ExamManagement() {
       ? `${exam.subject} • ${exam.className} • ${exam.term} • ${exam.session}`
       : "Exam Result"
 
+    const sanitize = (value: string) =>
+      value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+
+    const schoolName = sanitize(resolvedSchoolName || "School")
+    const logoMarkup = resolvedLogo
+      ? `<div style="margin-bottom:12px;"><img src="${resolvedLogo}" alt="School logo" style="height:72px;object-fit:contain;" /></div>`
+      : ""
+
     printWindow.document.write(`<!DOCTYPE html>
       <html>
         <head>
@@ -787,7 +804,8 @@ export default function ExamManagement() {
         </head>
         <body>
           <div class="header">
-            <h2>VEA 2025 Result Slip</h2>
+            ${logoMarkup}
+            <h2>${schoolName} Result Slip</h2>
             <p>${examLabel}</p>
           </div>
           <div class="meta">

--- a/components/librarian-dashboard.tsx
+++ b/components/librarian-dashboard.tsx
@@ -20,6 +20,7 @@ import { BookOpen, Search, Plus, Users, Calendar, AlertTriangle } from "lucide-r
 import { dbManager } from "@/lib/database-manager"
 import { useToast } from "@/hooks/use-toast"
 import { TutorialLink } from "@/components/tutorial-link"
+import { useBranding } from "@/hooks/use-branding"
 
 interface LibrarianDashboardProps {
   librarian: {
@@ -75,6 +76,8 @@ interface BookRequestRecord {
 }
 
 export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
+  const branding = useBranding()
+  const resolvedSchoolName = branding.schoolName
   const [selectedTab, setSelectedTab] = useState("overview")
   const [searchTerm, setSearchTerm] = useState("")
   const [books, setBooks] = useState<InventoryBook[]>([])
@@ -438,7 +441,7 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-2xl font-bold">Welcome, {librarian.name}</h1>
-            <p className="text-green-100">Library Management - VEA 2025</p>
+            <p className="text-green-100">Library Management - {resolvedSchoolName}</p>
           </div>
           <TutorialLink
             href="https://www.youtube.com/watch?v=3GwjfUFyY6M"

--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -40,6 +40,7 @@ import { dbManager } from "@/lib/database-manager"
 import { logger } from "@/lib/logger"
 import { normalizeTimetableCollection } from "@/lib/timetable"
 import { CONTINUOUS_ASSESSMENT_MAXIMUMS } from "@/lib/grade-utils"
+import { useBranding } from "@/hooks/use-branding"
 
 type TimetableSlotSummary = TimetableWeeklyViewSlot
 
@@ -190,6 +191,8 @@ interface StudentDashboardProps {
 }
 
 export function StudentDashboard({ student }: StudentDashboardProps) {
+  const branding = useBranding()
+  const resolvedSchoolName = branding.schoolName
   const [selectedTab, setSelectedTab] = useState("overview")
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false)
   const [selectedAssignment, setSelectedAssignment] = useState<IdentifiedRecord | null>(null)
@@ -698,7 +701,7 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
           <div>
             <h1 className="text-2xl font-bold">Welcome, {studentProfile.name}</h1>
             <p className="text-green-100">
-              Student Portal - {(studentProfile.class || effectiveClassName) ?? "Unassigned"} - VEA 2025
+              Student Portal - {(studentProfile.class || effectiveClassName) ?? "Unassigned"} - {resolvedSchoolName}
             </p>
             <p className="text-sm text-green-200">
               Admission No: {studentProfile.admissionNumber || student.admissionNumber}


### PR DESCRIPTION
## Summary
- render the super admin configured branding logo/name on the login screen and shared dashboard header using `useBranding`
- surface the active school name branding on student, librarian, and accountant dashboards
- embed the uploaded logo and sanitized school name in the printable exam result slip output

## Testing
- `pnpm lint` *(fails: existing lint violations across the repository unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a26af22483279845b93e69d92b77