### PR TITLE
Improve report card branding integration and downloads

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -318,6 +318,27 @@
 
 /* Print styles for report cards */
 @media print {
+  body * {
+    visibility: hidden;
+  }
+
+  .report-card-print-area,
+  .report-card-print-area * {
+    visibility: visible;
+  }
+
+  .report-card-print-area {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0 !important;
+    background-color: white !important;
+    padding: 0 !important;
+    width: auto !important;
+    max-width: 210mm !important;
+  }
+
   .print\:hidden {
     display: none !important;
   }

--- a/components/report-card-viewer.tsx
+++ b/components/report-card-viewer.tsx
@@ -80,7 +80,7 @@ export function ReportCardViewer({
   return (
     <div className="space-y-6">
       {/* Selection Controls */}
-      <div className="flex gap-4 items-end">
+      <div className="flex gap-4 items-end print:hidden">
         <div>
           <Label>Term</Label>
           <Select value={selectedTerm} onValueChange={setSelectedTerm}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "embla-carousel-react": "8.5.1",
         "express-rate-limit": "^7.1.5",
         "geist": "^1.3.1",
+        "html-to-image": "^1.11.11",
         "input-otp": "1.4.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.454.0",
@@ -7390,6 +7391,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
+    "html-to-image": "^1.11.11",
     "express-rate-limit": "^7.1.5",
     "geist": "^1.3.1",
     "input-otp": "1.4.1",


### PR DESCRIPTION
## Summary
- wire super admin branding updates directly into the cached branding store and trim saved values
- enhance the printable report card header with contact details, tighten print-only styling, and add a PNG download action
- ensure report card selections are hidden from print output and build cumulative summaries from stored marks when exam results are absent
- add html-to-image dependency for exporting report cards as images

## Testing
- npm run lint *(fails: repository has thousands of pre-existing lint violations unrelated to this change)*
- npm run type-check *(fails: repository currently has hundreds of TS errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ed64b1a483278af4c21458ab71bc