### PR TITLE
Align teacher and student dashboard tabs with scroll layout

### DIFF
--- a/components/librarian-dashboard.tsx
+++ b/components/librarian-dashboard.tsx
@@ -502,28 +502,28 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-4 lg:grid-cols-8 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="books"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Books
             </TabsTrigger>
             <TabsTrigger
               value="borrowed"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Borrowed
             </TabsTrigger>
             <TabsTrigger
               value="requests"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Requests
             </TabsTrigger>

--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -785,40 +785,40 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-6 lg:grid-cols-12 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="subjects"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Subjects
             </TabsTrigger>
             <TabsTrigger
               value="timetable"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Timetable
             </TabsTrigger>
             <TabsTrigger
               value="assignments"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Assignments
             </TabsTrigger>
             <TabsTrigger
               value="materials"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Materials
             </TabsTrigger>
             <TabsTrigger
               value="library"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Library
             </TabsTrigger>

--- a/components/super-admin-dashboard.tsx
+++ b/components/super-admin-dashboard.tsx
@@ -1064,58 +1064,58 @@ export default function SuperAdminDashboard() {
 
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DashboardTab)}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-9 lg:grid-cols-16 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="branding"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Branding
             </TabsTrigger>
             <TabsTrigger
               value="messages"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Messages
             </TabsTrigger>
             <TabsTrigger
               value="approval"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Report Approval
             </TabsTrigger>
             <TabsTrigger
               value="receipts"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Payments
             </TabsTrigger>
             <TabsTrigger
               value="students"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Students
             </TabsTrigger>
             <TabsTrigger
               value="users"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Users
             </TabsTrigger>
             <TabsTrigger
               value="system"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               System
             </TabsTrigger>
             <TabsTrigger
               value="reports"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Reports
             </TabsTrigger>

--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -2220,58 +2220,58 @@ export function TeacherDashboard({ teacher }: TeacherDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-9 lg:grid-cols-16 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="profile"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger
               value="marks"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Enter Marks
             </TabsTrigger>
             <TabsTrigger
               value="assignments"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Assignments
             </TabsTrigger>
             <TabsTrigger
               value="students"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Students
             </TabsTrigger>
             <TabsTrigger
               value="timetable"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Timetable
             </TabsTrigger>
             <TabsTrigger
               value="materials"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Materials
             </TabsTrigger>
             <TabsTrigger
               value="noticeboard"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Noticeboard
             </TabsTrigger>
             <TabsTrigger
               value="messages"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Messages
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- switch the teacher and student dashboard tab lists to a horizontal flex layout so they scroll instead of wrapping
- widen each tab trigger to keep labels readable while scrolling
- apply the same scroll-friendly tab layout to the librarian dashboard navigation for consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71258795c8327a7023c985b7030b6