### PR TITLE
Improve admin and super admin overview grids on mobile

### DIFF
--- a/components/admin/system-overview.tsx
+++ b/components/admin/system-overview.tsx
@@ -169,7 +169,7 @@ export function SystemOverview() {
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2 md:grid-cols-4">
         <StatCard
           title="Total Students"
           description="Registered student accounts"

--- a/components/super-admin-dashboard.tsx
+++ b/components/super-admin-dashboard.tsx
@@ -1129,7 +1129,7 @@ export default function SuperAdminDashboard() {
             </Card>
           ) : (
             <>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+              <div className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2 md:grid-cols-4">
                 <Card>
                   <CardContent className="flex items-center justify-between p-4">
                     <div>


### PR DESCRIPTION
## Summary
- update the admin dashboard overview grid to use a two-column layout on small screens while retaining four columns on larger viewports
- apply the same responsive two-column layout to the super admin dashboard overview grid for better mobile usability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d73c157da48327ab19c73735c31d91