### PR TITLE
Add scrollable status tabs to payment records

### DIFF
--- a/components/admin/payment-management.tsx
+++ b/components/admin/payment-management.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CreditCard, Search, CheckCircle, XCircle, Clock, DollarSign, Loader2 } from "lucide-react"
 import { ParentAccessManager } from "@/components/parent-access-manager"
 
@@ -76,11 +77,14 @@ function mapPayment(record: ApiPaymentRecord): PaymentRecord {
   }
 }
 
+type StatusFilter = "all" | PaymentRecord["status"]
+
 export function PaymentManagement() {
   const [payments, setPayments] = useState<PaymentRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
   const [updatingId, setUpdatingId] = useState<string | null>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
 
@@ -153,6 +157,10 @@ export function PaymentManagement() {
 
   const filteredPayments = useMemo(() => {
     return payments.filter((payment) => {
+      if (statusFilter !== "all" && payment.status !== statusFilter) {
+        return false
+      }
+
       const term = searchTerm.trim().toLowerCase()
       if (!term) {
         return true
@@ -163,7 +171,7 @@ export function PaymentManagement() {
         (payment.reference ?? "").toLowerCase().includes(term)
       )
     })
-  }, [payments, searchTerm])
+  }, [payments, searchTerm, statusFilter])
 
   const totals = useMemo(() => {
     const totalRevenue = payments
@@ -292,7 +300,43 @@ export function PaymentManagement() {
           </div>
         </CardHeader>
 
-        <CardContent className="p-0">
+        <CardContent className="space-y-4 p-0">
+          <div className="px-4 pt-4">
+            <Tabs
+              value={statusFilter}
+              onValueChange={(value) => setStatusFilter(value as StatusFilter)}
+              className="w-full"
+            >
+              <div className="w-full overflow-x-auto">
+                <TabsList className="flex w-max flex-nowrap gap-1 rounded-md bg-green-50 p-1">
+                  <TabsTrigger
+                    value="all"
+                    className="min-w-[100px] px-3 py-2 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
+                  >
+                    All
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="paid"
+                    className="min-w-[100px] px-3 py-2 text-xs capitalize data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
+                  >
+                    Paid
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="pending"
+                    className="min-w-[100px] px-3 py-2 text-xs capitalize data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
+                  >
+                    Pending
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="failed"
+                    className="min-w-[100px] px-3 py-2 text-xs capitalize data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
+                  >
+                    Failed
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+            </Tabs>
+          </div>
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>

--- a/components/librarian-dashboard.tsx
+++ b/components/librarian-dashboard.tsx
@@ -502,28 +502,28 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-4 lg:grid-cols-8 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="books"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Books
             </TabsTrigger>
             <TabsTrigger
               value="borrowed"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Borrowed
             </TabsTrigger>
             <TabsTrigger
               value="requests"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Requests
             </TabsTrigger>

--- a/components/parent-access-manager.tsx
+++ b/components/parent-access-manager.tsx
@@ -256,52 +256,54 @@ export function ParentAccessManager({
             No parent records available. Add parents to manage manual access.
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Parent</TableHead>
-                <TableHead>Student</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Manual Access</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((row) => (
-                <TableRow key={row.key}>
-                  <TableCell>
-                    <div className="font-medium text-[#2d682d]">{row.parent.name}</div>
-                    <div className="text-xs text-gray-500">{row.parent.email}</div>
-                  </TableCell>
-                  <TableCell>
-                    {row.student ? (
-                      <div>
-                        <div className="font-medium">{row.student.name}</div>
-                        <div className="text-xs text-gray-500">{row.student.className ?? "Class not set"}</div>
-                      </div>
-                    ) : (
-                      <span className="text-xs text-red-600">No linked student</span>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    {row.grantedBy ? (
-                      <Badge variant="outline" className="capitalize">
-                        {row.grantedBy === "manual" ? "Manual" : "Payment"}
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className="text-gray-500">Not granted</Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="flex justify-end">
-                    <Switch
-                      checked={row.hasAccess}
-                      disabled={row.disabled}
-                      onCheckedChange={(checked) => handleToggle(row.parent.id, row.student?.id ?? null, checked)}
-                    />
-                  </TableCell>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Parent</TableHead>
+                  <TableHead>Student</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Manual Access</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.key}>
+                    <TableCell>
+                      <div className="font-medium text-[#2d682d]">{row.parent.name}</div>
+                      <div className="text-xs text-gray-500">{row.parent.email}</div>
+                    </TableCell>
+                    <TableCell>
+                      {row.student ? (
+                        <div>
+                          <div className="font-medium">{row.student.name}</div>
+                          <div className="text-xs text-gray-500">{row.student.className ?? "Class not set"}</div>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-red-600">No linked student</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.grantedBy ? (
+                        <Badge variant="outline" className="capitalize">
+                          {row.grantedBy === "manual" ? "Manual" : "Payment"}
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-gray-500">Not granted</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="flex justify-end">
+                      <Switch
+                        checked={row.hasAccess}
+                        disabled={row.disabled}
+                        onCheckedChange={(checked) => handleToggle(row.parent.id, row.student?.id ?? null, checked)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -785,40 +785,40 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-6 lg:grid-cols-12 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="subjects"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Subjects
             </TabsTrigger>
             <TabsTrigger
               value="timetable"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Timetable
             </TabsTrigger>
             <TabsTrigger
               value="assignments"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Assignments
             </TabsTrigger>
             <TabsTrigger
               value="materials"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Materials
             </TabsTrigger>
             <TabsTrigger
               value="library"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Library
             </TabsTrigger>

--- a/components/super-admin-dashboard.tsx
+++ b/components/super-admin-dashboard.tsx
@@ -1064,58 +1064,58 @@ export default function SuperAdminDashboard() {
 
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DashboardTab)}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-9 lg:grid-cols-16 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="branding"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Branding
             </TabsTrigger>
             <TabsTrigger
               value="messages"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Messages
             </TabsTrigger>
             <TabsTrigger
               value="approval"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Report Approval
             </TabsTrigger>
             <TabsTrigger
               value="receipts"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Payments
             </TabsTrigger>
             <TabsTrigger
               value="students"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Students
             </TabsTrigger>
             <TabsTrigger
               value="users"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Users
             </TabsTrigger>
             <TabsTrigger
               value="system"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               System
             </TabsTrigger>
             <TabsTrigger
               value="reports"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Reports
             </TabsTrigger>

--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -2220,58 +2220,58 @@ export function TeacherDashboard({ teacher }: TeacherDashboardProps) {
       {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <div className="w-full overflow-x-auto">
-          <TabsList className="grid w-full min-w-max grid-cols-9 lg:grid-cols-16 bg-green-50 gap-1 p-1">
+          <TabsList className="flex w-max flex-nowrap gap-1 bg-green-50 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="profile"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Profile
             </TabsTrigger>
             <TabsTrigger
               value="marks"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Enter Marks
             </TabsTrigger>
             <TabsTrigger
               value="assignments"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Assignments
             </TabsTrigger>
             <TabsTrigger
               value="students"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Students
             </TabsTrigger>
             <TabsTrigger
               value="timetable"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Timetable
             </TabsTrigger>
             <TabsTrigger
               value="materials"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Materials
             </TabsTrigger>
             <TabsTrigger
               value="noticeboard"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Noticeboard
             </TabsTrigger>
             <TabsTrigger
               value="messages"
-              className="data-[state=active]:bg-[#2d682d] data-[state=active]:text-white text-xs px-2"
+              className="min-w-[120px] px-3 text-xs data-[state=active]:bg-[#2d682d] data-[state=active]:text-white"
             >
               Messages
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- add a horizontal, scrollable status filter to the payment records table so long labels stay readable on smaller screens
- wrap the parent access manager table in a horizontal scroller to keep columns accessible without squeezing content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71258795c8327a7023c985b7030b6