### PR TITLE
Fix sentence scramble timer hook ordering in student dashboard

### DIFF
--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -738,6 +738,16 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
     ? Math.min((sentenceAttempts.length / totalSentenceRounds) * 100, 100)
     : 0
 
+  const getSentenceRoundDuration = useCallback(
+    (round: SentenceScrambleRound | null | undefined) => {
+      if (!round) {
+        return difficultyDurations.medium
+      }
+      return difficultyDurations[round.difficulty]
+    },
+    [],
+  )
+
   const currentSentenceDuration = useMemo(
     () => getSentenceRoundDuration(currentSentenceRound),
     [currentSentenceRound, getSentenceRoundDuration],
@@ -765,16 +775,6 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
   const sentenceAccuracy = sentenceAttempts.length
     ? Math.round((totalSentenceCorrect / sentenceAttempts.length) * 100)
     : 0
-
-  const getSentenceRoundDuration = useCallback(
-    (round: SentenceScrambleRound | null | undefined) => {
-      if (!round) {
-        return difficultyDurations.medium
-      }
-      return difficultyDurations[round.difficulty]
-    },
-    [],
-  )
 
   const prepareSentenceRound = useCallback(
     (round: SentenceScrambleRound | null) => {


### PR DESCRIPTION
## Summary
- define the sentence round duration hook before dependent memoization
- prevent the student dashboard from throwing runtime errors when computing sentence timers

## Testing
- npm run lint *(fails: existing lint violations throughout repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d79b16ab28832795a80ddb554e259f