### PR TITLE
Align student login identity with seeded assignment data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -181,7 +181,7 @@ const FALLBACK_ACCOUNTS: FallbackAccount[] = [
     token: "demo-token-teacher",
   },
   {
-    id: "user_student",
+    id: "student_john_doe",
     email: "student@vea.edu.ng",
     password: "Student2025!",
     role: "student",
@@ -202,7 +202,7 @@ const FALLBACK_ACCOUNTS: FallbackAccount[] = [
     name: "Parent Guardian",
     hasAccess: roleHasPortalAccess("parent"),
     metadata: {
-      linkedStudentId: "user_student",
+      linkedStudentId: "student_john_doe",
     },
     token: "demo-token-parent",
   },

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -537,6 +537,7 @@ interface DefaultUserSeed {
   role: string
   password: string
   classId?: string | null
+  className?: string | null
   studentIds?: string[]
   subjects?: string[]
   metadata?: Record<string, unknown> | null
@@ -576,12 +577,17 @@ function createDefaultUsers(): StoredUser[] {
       subjects: ["Mathematics", "English"],
     },
     {
-      id: "user_student",
+      id: "student_john_doe",
       name: "John Student",
       email: "student@vea.edu.ng",
       role: "student",
       password: "Student2025!",
       classId: "class_jss1a",
+      className: "JSS 1A",
+      metadata: {
+        className: "JSS 1A",
+        admissionNumber: "VEA2025001",
+      },
     },
     {
       id: "user_parent",
@@ -620,6 +626,7 @@ function createDefaultUsers(): StoredUser[] {
     isActive: true,
     status: "active",
     classId: seed.classId ?? null,
+    className: seed.className ?? null,
     studentIds: seed.studentIds ?? [],
     subjects: seed.subjects ?? [],
     metadata: seed.metadata ?? null,


### PR DESCRIPTION
## Summary
- align the student dashboard fallback account with the seeded `student_john_doe` identifier so assignment delivery targets the same student record
- update the default user seeds to use the same identifier and attach class metadata to preserve class-based assignment resolution
- extend the default user seed typing to carry class names into stored user records

## Testing
- npm run lint *(fails: pre-existing lint errors across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9470c0cb483279e232813a8d03082