### PR TITLE
Improve offline data fallbacks for registration and timetables

### DIFF
--- a/components/student-dashboard.tsx
+++ b/components/student-dashboard.tsx
@@ -1863,29 +1863,22 @@ export function StudentDashboard({ student }: StudentDashboardProps) {
             : normalizedAssignments
         setAssignments(filteredAssignments)
 
-        const timetableResponse = await fetch(
-          `/api/timetable?className=${encodeURIComponent(resolvedClassName)}`,
-        )
+        const timetableSlots = await dbManager.getTimetable(resolvedClassName)
         if (!isMounted) {
           return
         }
 
-        if (timetableResponse.ok) {
-          const timetableJson: unknown = await timetableResponse.json()
-          const normalized = normalizeTimetableCollection(
-            (timetableJson as Record<string, unknown>)?.timetable,
-          ).map(({ id, day, time, subject, teacher, location }) => ({
+        const normalizedTimetable = normalizeTimetableCollection(timetableSlots).map(
+          ({ id, day, time, subject, teacher, location }) => ({
             id,
             day,
             time,
             subject,
             teacher,
             location,
-          }))
-          setTimetable(normalized)
-        } else {
-          setTimetable([])
-        }
+          }),
+        )
+        setTimetable(normalizedTimetable)
 
         const libraryData = await dbManager.getLibraryBooks(resolvedStudentId)
         if (!isMounted) {

--- a/lib/database-manager.ts
+++ b/lib/database-manager.ts
@@ -8,6 +8,7 @@ import type { StoredSubjectRecord } from "./report-card-types"
 const serverSideStorage = new Map<string, string>()
 
 const isBrowserEnvironment = (): boolean => typeof window !== "undefined"
+const REMOTE_ASSIGNMENTS_API_ENABLED = process.env.NEXT_PUBLIC_ENABLE_REMOTE_API === "true"
 
 const readStorageValue = (key: string): string | null => {
   if (isBrowserEnvironment()) {
@@ -434,6 +435,10 @@ class DatabaseManager {
   }
 
   private shouldUseAssignmentsApi(): boolean {
+    if (!REMOTE_ASSIGNMENTS_API_ENABLED) {
+      return false
+    }
+
     return isBrowserEnvironment() && typeof fetch === "function"
   }
 


### PR DESCRIPTION
## Summary
- replace client-side registration fetches with database manager fallbacks for system settings, class options, and student listings
- load teacher and student timetable views from the local database manager and watch for timetable updates instead of hitting API routes
- gate assignment API usage behind a NEXT_PUBLIC_ENABLE_REMOTE_API flag so offline mode stops logging failed network requests

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da86b6b9448327a3d3ca3f82491db2