### PR TITLE
Add tests for assignment reminder helpers

### DIFF
--- a/__tests__/assignment-reminders.test.ts
+++ b/__tests__/assignment-reminders.test.ts
@@ -1,0 +1,71 @@
+import {
+  shouldSendAssignmentReminder,
+  markAssignmentReminderSent,
+  clearAssignmentReminderHistory,
+  type AssignmentReminderType,
+} from "@/lib/assignment-reminders"
+import { safeStorage } from "@/lib/safe-storage"
+
+describe("assignment reminder helpers", () => {
+  const STORAGE_KEY = "assignmentReminderLog"
+
+  const resetStorage = () => {
+    safeStorage.removeItem(STORAGE_KEY)
+  }
+
+  beforeEach(() => {
+    resetStorage()
+  })
+
+  it("allows reminders when no history exists and blocks repeat sends", () => {
+    const assignmentId = "assignment-1"
+
+    expect(shouldSendAssignmentReminder("student", assignmentId, "dueSoon")).toBe(true)
+
+    markAssignmentReminderSent("student", assignmentId, "dueSoon", { dueDate: "2024-01-01" })
+
+    expect(shouldSendAssignmentReminder("student", assignmentId, "dueSoon", { dueDate: "2024-01-01" })).toBe(false)
+  })
+
+  it("permits a resend when the due date changes", () => {
+    const assignmentId = "assignment-2"
+
+    markAssignmentReminderSent("teacher", assignmentId, "missingSubmissions", { dueDate: "2024-01-05" })
+
+    expect(
+      shouldSendAssignmentReminder("teacher", assignmentId, "missingSubmissions", { dueDate: "2024-01-05" }),
+    ).toBe(false)
+
+    expect(
+      shouldSendAssignmentReminder("teacher", assignmentId, "missingSubmissions", { dueDate: "2024-01-07" }),
+    ).toBe(true)
+  })
+
+  it("clears selected reminder types while preserving others", () => {
+    const assignmentId = "assignment-3"
+    const reminderTypes: AssignmentReminderType[] = ["dueSoon", "overdue", "gradingPending"]
+
+    reminderTypes.forEach((type, index) => {
+      const day = String(index + 1).padStart(2, "0")
+      markAssignmentReminderSent("student", assignmentId, type, { dueDate: `2024-02-${day}` })
+    })
+
+    clearAssignmentReminderHistory("student", assignmentId, { types: ["dueSoon", "gradingPending"] })
+
+    expect(shouldSendAssignmentReminder("student", assignmentId, "dueSoon", { dueDate: "2024-02-01" })).toBe(true)
+    expect(shouldSendAssignmentReminder("student", assignmentId, "gradingPending", { dueDate: "2024-02-03" })).toBe(true)
+    expect(shouldSendAssignmentReminder("student", assignmentId, "overdue", { dueDate: "2024-02-02" })).toBe(false)
+
+    clearAssignmentReminderHistory("student", assignmentId)
+
+    expect(shouldSendAssignmentReminder("student", assignmentId, "overdue", { dueDate: "2024-02-02" })).toBe(true)
+  })
+
+  it("ignores operations for empty assignment identifiers", () => {
+    expect(shouldSendAssignmentReminder("teacher", "", "overdue")).toBe(false)
+
+    markAssignmentReminderSent("teacher", "", "overdue")
+
+    expect(shouldSendAssignmentReminder("teacher", "", "overdue")).toBe(false)
+  })
+})

--- a/lib/assignment-reminders.ts
+++ b/lib/assignment-reminders.ts
@@ -1,0 +1,118 @@
+import { safeStorage } from "./safe-storage"
+
+export type AssignmentReminderAudience = "teacher" | "student"
+export type AssignmentReminderType = "dueSoon" | "overdue" | "gradingPending" | "missingSubmissions"
+
+interface AssignmentReminderEntry {
+  timestamp: string
+  dueDate?: string | null
+}
+
+interface AssignmentReminderLog {
+  teacher: Record<string, Partial<Record<AssignmentReminderType, AssignmentReminderEntry>>>
+  student: Record<string, Partial<Record<AssignmentReminderType, AssignmentReminderEntry>>>
+}
+
+const STORAGE_KEY = "assignmentReminderLog"
+
+const createDefaultLog = (): AssignmentReminderLog => ({ teacher: {}, student: {} })
+
+const readReminderLog = (): AssignmentReminderLog => {
+  try {
+    const raw = safeStorage.getItem(STORAGE_KEY)
+    if (!raw) {
+      return createDefaultLog()
+    }
+
+    const parsed = JSON.parse(raw) as AssignmentReminderLog
+    return {
+      teacher: parsed.teacher ?? {},
+      student: parsed.student ?? {},
+    }
+  } catch (error) {
+    console.error("Unable to parse assignment reminder log", error)
+    return createDefaultLog()
+  }
+}
+
+const writeReminderLog = (log: AssignmentReminderLog) => {
+  safeStorage.setItem(STORAGE_KEY, JSON.stringify(log))
+}
+
+export const shouldSendAssignmentReminder = (
+  audience: AssignmentReminderAudience,
+  assignmentId: string,
+  type: AssignmentReminderType,
+  options: { dueDate?: string | null } = {},
+): boolean => {
+  if (!assignmentId) {
+    return false
+  }
+
+  const log = readReminderLog()
+  const assignmentLog = log[audience][assignmentId]?.[type]
+
+  if (!assignmentLog) {
+    return true
+  }
+
+  if (options.dueDate && assignmentLog.dueDate && assignmentLog.dueDate !== options.dueDate) {
+    return true
+  }
+
+  return false
+}
+
+export const markAssignmentReminderSent = (
+  audience: AssignmentReminderAudience,
+  assignmentId: string,
+  type: AssignmentReminderType,
+  options: { dueDate?: string | null } = {},
+) => {
+  if (!assignmentId) {
+    return
+  }
+
+  const log = readReminderLog()
+  const assignmentEntries = log[audience][assignmentId] ?? {}
+  assignmentEntries[type] = {
+    timestamp: new Date().toISOString(),
+    dueDate: options.dueDate ?? null,
+  }
+
+  log[audience][assignmentId] = assignmentEntries
+  writeReminderLog(log)
+}
+
+export const clearAssignmentReminderHistory = (
+  audience: AssignmentReminderAudience,
+  assignmentId: string,
+  options: { types?: AssignmentReminderType[] } = {},
+) => {
+  if (!assignmentId) {
+    return
+  }
+
+  const log = readReminderLog()
+  const assignmentEntries = log[audience][assignmentId]
+
+  if (!assignmentEntries) {
+    return
+  }
+
+  if (options.types && options.types.length > 0) {
+    options.types.forEach((type) => {
+      if (assignmentEntries[type]) {
+        delete assignmentEntries[type]
+      }
+    })
+
+    if (Object.keys(assignmentEntries).length === 0) {
+      delete log[audience][assignmentId]
+    }
+  } else {
+    delete log[audience][assignmentId]
+  }
+
+  writeReminderLog(log)
+}


### PR DESCRIPTION
## Summary
- add a dedicated Jest suite that covers the assignment reminder helper utilities
- exercise reminder send gating, due date resets, targeted log clearing, and guard rails for empty IDs

## Testing
- npx jest __tests__/assignment-reminders.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68daea42bf3483279b597b62a2c017bb