### PR TITLE
Improve assignment distribution workflow

### DIFF
--- a/app/api/assignments/route.ts
+++ b/app/api/assignments/route.ts
@@ -39,6 +39,7 @@ export async function POST(request: NextRequest) {
       dueDate,
       maximumScore,
       status,
+      action,
       type,
       attachmentName,
       attachmentSize,
@@ -64,6 +65,24 @@ export async function POST(request: NextRequest) {
         message: "Assignment submitted successfully",
       })
     } else {
+      const normalizedAction = typeof action === "string" ? action.trim().toLowerCase() : ""
+      const normalizedStatus = typeof status === "string" ? status.trim().toLowerCase() : ""
+      const resolvedStatus = (() => {
+        if (normalizedStatus === "draft" || normalizedStatus === "sent") {
+          return normalizedStatus
+        }
+
+        if (normalizedAction === "draft" || normalizedAction === "save") {
+          return "draft"
+        }
+
+        if (normalizedAction === "sent" || normalizedAction === "send") {
+          return "sent"
+        }
+
+        return "sent"
+      })()
+
       const newAssignment = await dbManager.createAssignment({
         title,
         description,
@@ -73,7 +92,7 @@ export async function POST(request: NextRequest) {
         teacherId,
         teacherName,
         dueDate,
-        status: typeof status === "string" ? status : "sent",
+        status: resolvedStatus,
         maximumScore,
         assignedStudentIds: Array.isArray(assignedStudentIds) ? assignedStudentIds : undefined,
         resourceName: attachmentName ?? null,


### PR DESCRIPTION
## Summary
- wrap the teacher assignment dialog in a real form so the Save Draft and Send buttons submit intent-aware actions
- guard assignment saves from duplicate submissions and derive the requested action from the submitter element
- allow the assignments API to accept form-style `action` values and normalize them to draft or sent statuses

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68db009dbf8483279b05f80c758686a3