### PR TITLE
Fix ScrollArea ref handling to prevent infinite updates

### DIFF
--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -5,54 +5,54 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
 
 import { cn } from '@/lib/utils'
 
-function ScrollArea({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
-  return (
-    <ScrollAreaPrimitive.Root
-      data-slot="scroll-area"
-      className={cn('relative', className)}
-      {...props}
-    >
-      <ScrollAreaPrimitive.Viewport
-        data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1 overflow-auto"
-      >
-        {children}
-      </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
-      <ScrollAreaPrimitive.Corner />
-    </ScrollAreaPrimitive.Root>
-  )
-}
-
-function ScrollBar({
-  className,
-  orientation = 'vertical',
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
-  return (
-    <ScrollAreaPrimitive.ScrollAreaScrollbar
-      data-slot="scroll-area-scrollbar"
-      orientation={orientation}
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    data-slot="scroll-area"
+    className={cn('relative overflow-hidden', className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport
+      data-slot="scroll-area-viewport"
       className={cn(
-        'flex touch-none p-px transition-colors select-none',
-        orientation === 'vertical' &&
-          'h-full w-2.5 border-l border-l-transparent',
-        orientation === 'horizontal' &&
-          'h-2.5 flex-col border-t border-t-transparent',
-        className,
+        'size-full rounded-[inherit]',
+        'transition-[color,box-shadow] outline-none',
+        'focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-ring/50'
       )}
-      {...props}
     >
-      <ScrollAreaPrimitive.ScrollAreaThumb
-        data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
-      />
-    </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
-}
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    data-slot="scroll-area-scrollbar"
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none p-px transition-colors',
+      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
+      orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb
+      data-slot="scroll-area-thumb"
+      className="relative flex-1 rounded-full bg-border"
+    />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
 
 export { ScrollArea, ScrollBar }


### PR DESCRIPTION
### **User description**
## Summary
- convert the ScrollArea and ScrollBar components to use `React.forwardRef` so Radix can compose refs without infinite loops
- adjust the viewport styling to keep existing focus states while ensuring the root remains overflow-hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22840a4e88327b0e7185a929dd840


___

### **PR Type**
Bug fix


___

### **Description**
- Convert ScrollArea and ScrollBar to forwardRef pattern

- Add overflow-hidden to root element styling

- Remove overflow-auto from viewport to prevent conflicts

- Fix ref composition issues with Radix primitives


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Function Components"] --> B["forwardRef Components"]
  B --> C["Proper Ref Handling"]
  C --> D["Prevent Infinite Updates"]
  E["Viewport Styling"] --> F["Remove overflow-auto"]
  F --> G["Add overflow-hidden to root"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scroll-area.tsx</strong><dd><code>Convert to forwardRef pattern with styling fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/ui/scroll-area.tsx

<ul><li>Convert <code>ScrollArea</code> and <code>ScrollBar</code> from function components to <br><code>React.forwardRef</code><br> <li> Add <code>overflow-hidden</code> class to root element and remove <code>overflow-auto</code> <br>from viewport<br> <li> Set proper <code>displayName</code> properties for both components<br> <li> Reorganize className concatenation for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/134/files#diff-272a16f1043e5a61aa8170c48c2816deb97874efa872eb1f469f75bd179153f9">+46/-46</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

