### PR TITLE
Fix report card PDF export by bundling html-to-image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "embla-carousel-react": "8.5.1",
         "express-rate-limit": "^7.1.5",
         "geist": "^1.3.1",
+        "html-to-image": "^1.11.13",
         "input-otp": "1.4.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.454.0",
@@ -7390,6 +7391,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "embla-carousel-react": "8.5.1",
     "express-rate-limit": "^7.1.5",
     "geist": "^1.3.1",
+    "html-to-image": "^1.11.13",
     "input-otp": "1.4.1",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.454.0",


### PR DESCRIPTION
### **User description**
## Summary
- replace the failing CDN dynamic import with a browser-safe dynamic import of the bundled `html-to-image` module
- add `html-to-image@1.11.13` to the project dependencies so report card export works offline and in production

## Testing
- `npm run lint` *(fails: existing lint, console, and SSR-safety violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e252887ec08327b47d2d55f1421599


___

### **PR Type**
Bug fix


___

### **Description**
- Replace failing CDN import with bundled `html-to-image` module

- Add `html-to-image@1.11.13` as project dependency

- Improve module loading with fallback handling

- Enable offline PDF export functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CDN["CDN Import"] -- "replace" --> Bundle["Bundled Module"]
  Bundle -- "enables" --> Export["PDF Export"]
  Package["package.json"] -- "adds" --> Dependency["html-to-image@1.11.13"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>html-to-image-loader.ts</strong><dd><code>Replace CDN import with bundled module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/html-to-image-loader.ts

<ul><li>Replace CDN import with direct module import<br> <li> Add fallback handling for default export<br> <li> Improve error handling and module validation<br> <li> Update comments to reflect new loading strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/142/files#diff-546588b6bba2d6f4d00b379c5ab3d2c4f84fc8ac7efe0b3085596ed4856a5b7e">+11/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add html-to-image dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Add `html-to-image@1.11.13` as production dependency


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/142/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

