### PR TITLE
Add html-to-image dependency to pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.5.1(next@14.2.25(@babel/core@7.28.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2680,6 +2683,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -7017,6 +7023,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   http-errors@2.0.0:
     dependencies:


### PR DESCRIPTION
### **User description**
## Summary
- add the html-to-image dependency to the pnpm lockfile so the runtime loader can resolve the module during builds

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2573eaa008327a1ff2f54e602054e


___

### **PR Type**
Other


___

### **Description**
- Add html-to-image dependency to pnpm lockfile

- Enable runtime module resolution during builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pnpm-lock.yaml"] --> B["Add html-to-image@1.11.13"]
  B --> C["Enable build resolution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Add html-to-image dependency entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<ul><li>Add html-to-image dependency with version 1.11.13<br> <li> Include package resolution and snapshot entries<br> <li> Enable module resolution during CI builds</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/143/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

