### PR TITLE
Fix jsPDF loader to use UMD CDN script

### DIFF
--- a/lib/jspdf-loader.ts
+++ b/lib/jspdf-loader.ts
@@ -1,7 +1,7 @@
 // Utility for loading the jsPDF library from a CDN at runtime.
 // This keeps the bundle size smaller while allowing PDF generation features.
 
-const JSPDF_CDN_URL = "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js"
+const JSPDF_CDN_URL = "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"
 
 type JsPdfOrientation = "portrait" | "landscape"
 
@@ -45,27 +45,92 @@ export interface JsPdfModule {
   jsPDF: JsPdfConstructor
 }
 
+type JsPdfGlobalNamespace = {
+  jsPDF?: JsPdfConstructor
+}
+
 let modulePromise: Promise<JsPdfModule> | null = null
 
-async function loadModule(): Promise<JsPdfModule> {
-  const runtime =
-    typeof globalThis === "undefined"
-      ? undefined
-      : (globalThis as Window & typeof globalThis)
+function resolveRuntime(): (Window & typeof globalThis & { jspdf?: JsPdfGlobalNamespace }) | null {
+  if (typeof globalThis === "undefined") {
+    return null
+  }
 
-  if (!runtime || typeof runtime.document === "undefined") {
+  const runtime = globalThis as Window & typeof globalThis & {
+    jspdf?: JsPdfGlobalNamespace
+  }
+
+  if (typeof runtime.document === "undefined") {
+    return null
+  }
+
+  return runtime
+}
+
+function waitForScript(script: HTMLScriptElement, runtime: Window & typeof globalThis & { jspdf?: JsPdfGlobalNamespace }) {
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      script.removeEventListener("load", handleLoad)
+      script.removeEventListener("error", handleError)
+    }
+
+    const handleLoad = () => {
+      cleanup()
+      resolve()
+    }
+
+    const handleError = () => {
+      cleanup()
+      reject(new Error("Failed to load jsPDF script"))
+    }
+
+    script.addEventListener("load", handleLoad)
+    script.addEventListener("error", handleError)
+
+    // In case the script was already loaded before listeners were added.
+    if (runtime.jspdf?.jsPDF) {
+      cleanup()
+      resolve()
+    }
+  })
+}
+
+async function loadModule(): Promise<JsPdfModule> {
+  const runtime = resolveRuntime()
+
+  if (!runtime) {
     throw new Error("jsPDF can only be loaded in the browser")
   }
 
-  const loadedModule = await import(
-    /* webpackIgnore: true */ JSPDF_CDN_URL
-  )
-
-  if (typeof loadedModule?.jsPDF !== "function") {
-    throw new Error("jsPDF module failed to load")
+  if (runtime.jspdf?.jsPDF) {
+    return { jsPDF: runtime.jspdf.jsPDF }
   }
 
-  return loadedModule as JsPdfModule
+  const existingScript = runtime.document.querySelector(
+    'script[data-jspdf-loader="true"]',
+  ) as HTMLScriptElement | null
+
+  if (existingScript) {
+    await waitForScript(existingScript, runtime)
+  } else {
+    const script = runtime.document.createElement("script")
+    script.src = JSPDF_CDN_URL
+    script.async = true
+    script.defer = true
+    script.setAttribute("data-jspdf-loader", "true")
+
+    runtime.document.head.appendChild(script)
+
+    await waitForScript(script, runtime)
+  }
+
+  const globalNamespace = runtime.jspdf
+
+  if (!globalNamespace?.jsPDF) {
+    throw new Error("jsPDF global namespace is unavailable")
+  }
+
+  return { jsPDF: globalNamespace.jsPDF }
 }
 
 export async function getJsPdf(): Promise<JsPdfModule> {


### PR DESCRIPTION
### **User description**
## Summary
- switch the jsPDF loader to fetch the UMD build so the browser no longer hits bare @babel/runtime imports
- add runtime checks and script-loading guards to reuse an existing tag and expose the jsPDF constructor from the global namespace

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3627801e083278139be0fdb218de6


___

### **PR Type**
Bug fix


___

### **Description**
- Switch jsPDF CDN URL from ES module to UMD build

- Add runtime checks and script loading guards

- Implement global namespace detection for jsPDF constructor

- Prevent duplicate script loading with data attributes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ES Module CDN"] --> B["UMD CDN Build"]
  C["Direct Import"] --> D["Script Tag Loading"]
  D --> E["Global Namespace Access"]
  E --> F["Runtime Guards"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jspdf-loader.ts</strong><dd><code>Replace ES import with UMD script loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/jspdf-loader.ts

<ul><li>Changed CDN URL from ES module to UMD build<br> <li> Added runtime environment detection with <code>resolveRuntime()</code><br> <li> Implemented script tag loading with event listeners<br> <li> Added duplicate script prevention using data attributes<br> <li> Modified module loading to access global <code>jspdf</code> namespace</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/145/files#diff-a94ac491d8050d92e87adb6f8a370720cb07087c50a6da05c805b43e5423f9ba">+77/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

