### PR TITLE
Fix report card PDF centering

### DIFF
--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -663,20 +663,28 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
     const pdfWidth = pdf.internal.pageSize.getWidth()
     const pdfHeight = pdf.internal.pageSize.getHeight()
     const imageProps = pdf.getImageProperties(dataUrl)
-    const imageRatio = imageProps.width / imageProps.height
 
-    let renderWidth = pdfWidth
-    let renderHeight = renderWidth / imageRatio
+    const imageWidth = imageProps.width
+    const imageHeight = imageProps.height
+    const widthScale = pdfWidth / imageWidth
+    const heightScale = pdfHeight / imageHeight
+    const renderScale = Math.min(widthScale, heightScale)
 
-    if (renderHeight > pdfHeight) {
-      renderHeight = pdfHeight
-      renderWidth = renderHeight * imageRatio
-    }
+    const renderWidth = imageWidth * renderScale
+    const renderHeight = imageHeight * renderScale
+    const offsetX = Math.max((pdfWidth - renderWidth) / 2, 0)
+    const offsetY = Math.max((pdfHeight - renderHeight) / 2, 0)
 
-    const offsetX = (pdfWidth - renderWidth) / 2
-    const offsetY = (pdfHeight - renderHeight) / 2
-
-    pdf.addImage(dataUrl, "PNG", offsetX, offsetY, renderWidth, renderHeight, undefined, "FAST")
+    pdf.addImage(
+      dataUrl,
+      "PNG",
+      offsetX,
+      offsetY,
+      renderWidth,
+      renderHeight,
+      undefined,
+      "FAST",
+    )
 
     return pdf
   }, [reportCardData])

--- a/lib/jspdf-loader.ts
+++ b/lib/jspdf-loader.ts
@@ -1,7 +1,7 @@
 // Utility for loading the jsPDF library from a CDN at runtime.
 // This keeps the bundle size smaller while allowing PDF generation features.
 
-const JSPDF_CDN_URL = "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js"
+const JSPDF_CDN_URL = "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"
 
 type JsPdfOrientation = "portrait" | "landscape"
 
@@ -45,27 +45,92 @@ export interface JsPdfModule {
   jsPDF: JsPdfConstructor
 }
 
+type JsPdfGlobalNamespace = {
+  jsPDF?: JsPdfConstructor
+}
+
 let modulePromise: Promise<JsPdfModule> | null = null
 
-async function loadModule(): Promise<JsPdfModule> {
-  const runtime =
-    typeof globalThis === "undefined"
-      ? undefined
-      : (globalThis as Window & typeof globalThis)
+function resolveRuntime(): (Window & typeof globalThis & { jspdf?: JsPdfGlobalNamespace }) | null {
+  if (typeof globalThis === "undefined") {
+    return null
+  }
 
-  if (!runtime || typeof runtime.document === "undefined") {
+  const runtime = globalThis as Window & typeof globalThis & {
+    jspdf?: JsPdfGlobalNamespace
+  }
+
+  if (typeof runtime.document === "undefined") {
+    return null
+  }
+
+  return runtime
+}
+
+function waitForScript(script: HTMLScriptElement, runtime: Window & typeof globalThis & { jspdf?: JsPdfGlobalNamespace }) {
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      script.removeEventListener("load", handleLoad)
+      script.removeEventListener("error", handleError)
+    }
+
+    const handleLoad = () => {
+      cleanup()
+      resolve()
+    }
+
+    const handleError = () => {
+      cleanup()
+      reject(new Error("Failed to load jsPDF script"))
+    }
+
+    script.addEventListener("load", handleLoad)
+    script.addEventListener("error", handleError)
+
+    // In case the script was already loaded before listeners were added.
+    if (runtime.jspdf?.jsPDF) {
+      cleanup()
+      resolve()
+    }
+  })
+}
+
+async function loadModule(): Promise<JsPdfModule> {
+  const runtime = resolveRuntime()
+
+  if (!runtime) {
     throw new Error("jsPDF can only be loaded in the browser")
   }
 
-  const loadedModule = await import(
-    /* webpackIgnore: true */ JSPDF_CDN_URL
-  )
-
-  if (typeof loadedModule?.jsPDF !== "function") {
-    throw new Error("jsPDF module failed to load")
+  if (runtime.jspdf?.jsPDF) {
+    return { jsPDF: runtime.jspdf.jsPDF }
   }
 
-  return loadedModule as JsPdfModule
+  const existingScript = runtime.document.querySelector(
+    'script[data-jspdf-loader="true"]',
+  ) as HTMLScriptElement | null
+
+  if (existingScript) {
+    await waitForScript(existingScript, runtime)
+  } else {
+    const script = runtime.document.createElement("script")
+    script.src = JSPDF_CDN_URL
+    script.async = true
+    script.defer = true
+    script.setAttribute("data-jspdf-loader", "true")
+
+    runtime.document.head.appendChild(script)
+
+    await waitForScript(script, runtime)
+  }
+
+  const globalNamespace = runtime.jspdf
+
+  if (!globalNamespace?.jsPDF) {
+    throw new Error("jsPDF global namespace is unavailable")
+  }
+
+  return { jsPDF: globalNamespace.jsPDF }
 }
 
 export async function getJsPdf(): Promise<JsPdfModule> {


### PR DESCRIPTION
### **User description**
## Summary
- switch the jsPDF loader to fetch the UMD build so the browser no longer hits bare @babel/runtime imports
- add runtime checks and script-loading guards to reuse an existing tag and expose the jsPDF constructor from the global namespace
- scale the captured report card image to the PDF page using intrinsic dimensions so the export stays centered without clipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3627801e083278139be0fdb218de6


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix jsPDF module loading by switching to UMD build

- Improve PDF centering and scaling calculations

- Add runtime checks and script loading guards

- Prevent clipping with proper aspect ratio handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ES Module"] --> B["UMD Module"]
  C["Dynamic Import"] --> D["Script Tag Loading"]
  E["Simple Scaling"] --> F["Aspect Ratio Scaling"]
  G["PDF Generation"] --> H["Centered Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jspdf-loader.ts</strong><dd><code>Replace ES import with UMD script loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/jspdf-loader.ts

<ul><li>Switch from ES module to UMD build CDN URL<br> <li> Replace dynamic import with script tag loading<br> <li> Add runtime checks and global namespace detection<br> <li> Implement script loading guards and reuse logic</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/146/files#diff-a94ac491d8050d92e87adb6f8a370720cb07087c50a6da05c805b43e5423f9ba">+77/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enhanced-report-card.tsx</strong><dd><code>Improve PDF image scaling and centering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/enhanced-report-card.tsx

<ul><li>Replace aspect ratio calculation with scale-based approach<br> <li> Use intrinsic image dimensions for proper scaling<br> <li> Add Math.max guards to prevent negative offsets<br> <li> Improve PDF centering with better offset calculations</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/146/files#diff-0a81f68c0ff6bd44edbb7cad6468b18117f0e4ceb359c4ec5fb018228367d366">+21/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

