### PR TITLE
Adjust report card print layout width

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -354,9 +354,9 @@
   .report-card-print-area {
     position: static;
     transform: none;
-    margin: 0 !important;
+    margin: 0 auto !important;
     padding: 12mm !important;
-    width: 210mm !important;
+    width: calc(210mm - 24mm) !important;
     min-height: 297mm !important;
     box-sizing: border-box !important;
   }


### PR DESCRIPTION
## Summary
- center the printed report card by restoring automatic horizontal margins
- reduce the printable area's width to account for padding and avoid left-side clipping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36b99d600832797950b0452ef22fd