### PR TITLE
Fix print layout spacing and passport visibility

### DIFF
--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -1238,7 +1238,8 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
         .photo-placeholder img {
           width: 100%;
           height: 100%;
-          object-fit: cover;
+          object-fit: contain;
+          padding: 6px;
         }
 
         .report-title {
@@ -1450,6 +1451,15 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
         }
 
         @media print {
+          @page {
+            size: A4 portrait;
+            margin: 12mm 10mm;
+          }
+
+          body {
+            margin: 0;
+          }
+
           .victory-report-card-wrapper {
             padding: 0;
           }
@@ -1460,11 +1470,13 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
 
           .victory-report-card {
             width: 100%;
+            justify-content: center;
           }
 
           .victory-report-card .report-container {
-            width: 190mm !important;
-            max-width: none;
+            width: 100% !important;
+            max-width: 186mm;
+            margin: 0 auto !important;
             border-width: 3px;
           }
         }


### PR DESCRIPTION
## Summary
- switch the student passport image to use `object-fit: contain` with padding so it prints fully
- tweak print-specific styles to set page margins and center the report card for even spacing

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68e377cf4ee08327b55eca83a2b21102