### PR TITLE
Improve print layout for enhanced report card

### DIFF
--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -1496,7 +1496,7 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
         @media print {
           @page {
             size: auto;
-            margin: 0;
+            margin: 10mm;
           }
 
           body {
@@ -1589,12 +1589,25 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
           }
 
           .remark-section {
-            gap: 10px;
+            gap: 8mm;
+            padding: 0 8mm 6mm;
           }
 
           .teacher-remarks,
           .domain-block {
             font-size: 9.5pt;
+            max-width: 100%;
+          }
+
+          .remarks-column {
+            flex: 1 1 48%;
+            min-width: 0;
+          }
+
+          .psychomotor-block,
+          .affective-block {
+            min-width: 0;
+            flex: 1 1 48%;
           }
 
           .vacation-box,
@@ -1605,6 +1618,15 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
 
           .grading-key-container {
             font-size: 9pt;
+          }
+
+          .af-domain-table {
+            table-layout: fixed;
+          }
+
+          .af-domain-table th,
+          .af-domain-table td {
+            word-break: break-word;
           }
 
           .logo {


### PR DESCRIPTION
## Summary
- increase the printed page margin so the report card border is no longer clipped
- adjust the print layout for the remarks and domain tables to keep affective domain content within bounds
- force fixed table layout and word wrapping so domain tables don’t overflow when printed

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e38893d6f48327a23187ddc909d941