### PR TITLE
Adjust holistic development tables to stay within report border

### DIFF
--- a/lib/report-card-html.ts
+++ b/lib/report-card-html.ts
@@ -216,6 +216,30 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
           justify-content: space-between;
           align-items: center;
         }
+        .holistic-grid {
+          gap: 12px;
+        }
+        .holistic-grid > div {
+          min-width: 0;
+        }
+        .holistic-grid table {
+          width: 100%;
+          max-width: 100%;
+          table-layout: fixed;
+          margin: 12px 0 0;
+          box-sizing: border-box;
+        }
+        .holistic-grid th,
+        .holistic-grid td {
+          padding: 8px;
+          word-break: break-word;
+          overflow-wrap: anywhere;
+          text-align: center;
+        }
+        .holistic-grid th:first-child,
+        .holistic-grid td:first-child {
+          text-align: left;
+        }
       </style>
     </head>
     <body>
@@ -328,7 +352,7 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
 
       <section class="section">
         <h2>Holistic Development</h2>
-        <div class="grid">
+        <div class="grid holistic-grid">
           <div>
             <h3>Affective Domain</h3>
             <table>


### PR DESCRIPTION
### **User description**
## Summary
- add a dedicated holistic grid style to keep affective and psychomotor tables inside the report card border
- update the holistic development section to use the new responsive grid styling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e39c9ff5f88327a172945e4c1709ab


___

### **PR Type**
Bug fix


___

### **Description**
- Add dedicated CSS styling for holistic development tables

- Prevent table overflow beyond report card borders

- Implement responsive grid layout with proper text wrapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Report Card HTML"] --> B["Add holistic-grid CSS"]
  B --> C["Apply to holistic section"]
  C --> D["Tables fit within borders"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report-card-html.ts</strong><dd><code>Add responsive CSS for holistic tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/report-card-html.ts

<ul><li>Add <code>.holistic-grid</code> CSS class with responsive table styling<br> <li> Set <code>table-layout: fixed</code> and <code>max-width: 100%</code> for proper sizing<br> <li> Configure text wrapping with <code>word-break</code> and <code>overflow-wrap</code><br> <li> Apply new styling to holistic development section grid</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/vea-2025/pull/157/files#diff-002c3b9ec969ae4b9a5c69c193795d7c1684d6a31e8bead6f819c4ad699b619d">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

