### PR TITLE
Fix subject memo initialization order in teacher dashboard

### DIFF
--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -498,6 +498,24 @@ export function TeacherDashboard({
 
   const normalizeClassName = useCallback((value: string) => value.replace(/\s+/g, "").toLowerCase(), [])
 
+  const subjectsForSelectedClass = useMemo(() => {
+    if (teacher.classes.length === 0) {
+      return teacher.subjects
+    }
+
+    const normalized = normalizeClassName(selectedClass)
+    if (!normalized) {
+      return teacher.classes[0]?.subjects.length ? teacher.classes[0]?.subjects : teacher.subjects
+    }
+
+    const match = teacher.classes.find((cls) => normalizeClassName(cls.name) === normalized)
+    if (match && match.subjects.length > 0) {
+      return match.subjects
+    }
+
+    return teacher.subjects
+  }, [normalizeClassName, selectedClass, teacher.classes, teacher.subjects])
+
   useEffect(() => {
     setSelectedClass(teacherClassNames[0] ?? "")
   }, [teacherClassNames])
@@ -541,24 +559,6 @@ export function TeacherDashboard({
       return value
     }
   }
-
-  const subjectsForSelectedClass = useMemo(() => {
-    if (teacher.classes.length === 0) {
-      return teacher.subjects
-    }
-
-    const normalized = normalizeClassName(selectedClass)
-    if (!normalized) {
-      return teacher.classes[0]?.subjects.length ? teacher.classes[0]?.subjects : teacher.subjects
-    }
-
-    const match = teacher.classes.find((cls) => normalizeClassName(cls.name) === normalized)
-    if (match && match.subjects.length > 0) {
-      return match.subjects
-    }
-
-    return teacher.subjects
-  }, [normalizeClassName, selectedClass, teacher.classes, teacher.subjects])
 
   useEffect(() => {
     if (subjectsForSelectedClass.length === 0) {


### PR DESCRIPTION
## Summary
- ensure the memoized subjects list is defined before effects that depend on it to avoid runtime reference errors in the teacher dashboard

## Testing
- npx eslint components/teacher-dashboard.tsx *(fails: pre-existing lint violations in teacher-dashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e47f7441888327b0909a9568dba305