### PR TITLE
Fix empty value select items in teacher dashboard

### DIFF
--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -3832,7 +3832,7 @@ export function TeacherDashboard({
                       </SelectTrigger>
                       <SelectContent>
                         {noClassesAssigned ? (
-                          <SelectItem value="" disabled>
+                          <SelectItem value="__no_classes__" disabled>
                             {isContextLoading ? "Loading..." : "No classes available"}
                           </SelectItem>
                         ) : (
@@ -3864,7 +3864,7 @@ export function TeacherDashboard({
                       </SelectTrigger>
                       <SelectContent>
                         {subjectsForSelectedClass.length === 0 ? (
-                          <SelectItem value="" disabled>
+                          <SelectItem value="__no_subjects__" disabled>
                             {noClassesAssigned ? "No class assigned" : "No subjects available"}
                           </SelectItem>
                         ) : (


### PR DESCRIPTION
## Summary
- assign non-empty sentinel values to disabled SelectItem placeholders in the teacher dashboard
- prevent Radix Select runtime errors triggered by empty string item values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4808a4d0883278dc44ae28b4522fd