### PR TITLE
Display branding logo and signature on report cards

### DIFF
--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -1138,14 +1138,23 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
           </div>
 
           <div className="signatures-box">
-            <span>
-              Teacher&apos;s Signature:
+            <div className="signature-item">
+              <span className="signature-label">Teacher&apos;s Signature:</span>
               <div className="signature-line" />
-            </span>
-            <span>
-              Headmaster&apos;s Signature:
-              <div className="signature-line" />
-            </span>
+            </div>
+            <div className="signature-item">
+              <span className="signature-label">Headmaster&apos;s Signature:</span>
+              {reportCardData.branding.signature ? (
+                <div className="signature-image">
+                  <img src={reportCardData.branding.signature} alt="Headmaster's signature" />
+                </div>
+              ) : (
+                <div className="signature-line" />
+              )}
+              {reportCardData.branding.headmasterName ? (
+                <span className="signature-name">{reportCardData.branding.headmasterName}</span>
+              ) : null}
+            </div>
           </div>
 
           <div className="grading-key-container">
@@ -1412,8 +1421,7 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
           min-width: 280px;
         }
 
-        .vacation-box,
-        .signatures-box {
+        .vacation-box {
           display: flex;
           gap: 24px;
           margin-top: 6px;
@@ -1422,19 +1430,55 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
           padding: 0 15px 8px;
         }
 
+        .signatures-box {
+          display: flex;
+          gap: 24px;
+          margin-top: 6px;
+          font-size: 1em;
+          align-items: flex-start;
+          padding: 0 15px 8px;
+          flex-wrap: wrap;
+        }
+
+        .signature-item {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          font-weight: 600;
+          color: #27613d;
+        }
+
+        .signature-label {
+          font-size: 1em;
+        }
+
         .signature-line {
           border-bottom: 1px dotted #27613d;
-          width: 110px;
+          width: 140px;
           height: 2px;
           margin-top: 12px;
           display: inline-block;
         }
 
-        .signatures-box span {
+        .signature-image {
+          width: 140px;
+          height: 70px;
           display: flex;
-          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .signature-image img {
+          max-width: 100%;
+          max-height: 100%;
+          object-fit: contain;
+        }
+
+        .signature-name {
+          font-size: 0.85em;
           font-weight: 600;
-          color: #27613d;
+          color: #1b4332;
+          letter-spacing: 0.02em;
         }
 
         .af-domain-table {

--- a/lib/report-card-html.ts
+++ b/lib/report-card-html.ts
@@ -143,9 +143,39 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
           display: flex;
           justify-content: space-between;
           align-items: center;
+          gap: 24px;
           margin-bottom: 30px;
           padding-bottom: 20px;
           border-bottom: 2px solid #2d682d;
+        }
+        .logo-container {
+          width: 100px;
+          height: 100px;
+          border: 2px solid #2d682d;
+          border-radius: 16px;
+          background: #f0fdf4;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          overflow: hidden;
+          flex-shrink: 0;
+        }
+        .logo-container img {
+          width: 100%;
+          height: 100%;
+          object-fit: contain;
+        }
+        .logo-placeholder {
+          font-size: 12px;
+          font-weight: 600;
+          color: #6b7280;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          text-align: center;
+          padding: 0 8px;
+        }
+        .header-info {
+          flex: 1;
         }
         .school-name {
           font-size: 24px;
@@ -214,7 +244,37 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
           margin-top: 40px;
           display: flex;
           justify-content: space-between;
+          align-items: flex-end;
+          gap: 40px;
+          flex-wrap: wrap;
+        }
+        .signature > div {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          min-width: 200px;
+        }
+        .signature-line {
+          border-bottom: 1px solid #d1d5db;
+          width: 200px;
+          height: 1px;
+        }
+        .signature-image {
+          width: 200px;
+          height: 80px;
+          display: flex;
           align-items: center;
+          justify-content: center;
+        }
+        .signature-image img {
+          max-width: 100%;
+          max-height: 100%;
+          object-fit: contain;
+        }
+        .signature-name {
+          font-size: 14px;
+          font-weight: 600;
+          color: #1b4332;
         }
         .holistic-grid {
           gap: 12px;
@@ -244,7 +304,14 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
     </head>
     <body>
       <header class="header">
-        <div>
+        <div class="logo-container">
+          ${
+            data.branding?.logo
+              ? `<img src="${escapeHtml(data.branding.logo)}" alt="School logo" />`
+              : '<div class="logo-placeholder">School Logo</div>'
+          }
+        </div>
+        <div class="header-info">
           <div class="school-name">${escapeHtml(data.branding?.schoolName ?? "Victory Educational Academy")}</div>
           ${
             data.branding?.address
@@ -441,11 +508,20 @@ export const buildReportCardHtml = (data: RawReportCardData) => {
       <div class="signature">
         <div>
           <div class="muted">Class Teacher Signature</div>
-          <div style="margin-top: 40px; border-bottom: 1px solid #d1d5db; width: 200px;"></div>
+          <div class="signature-line"></div>
         </div>
         <div>
           <div class="muted">Head Teacher Signature</div>
-          <div style="margin-top: 40px; border-bottom: 1px solid #d1d5db; width: 200px;"></div>
+          ${
+            data.branding?.signature
+              ? `<div class="signature-image"><img src="${escapeHtml(data.branding.signature)}" alt="Head Teacher signature" /></div>`
+              : '<div class="signature-line"></div>'
+          }
+          ${
+            data.branding?.headmasterName
+              ? `<div class="signature-name">${escapeHtml(data.branding.headmasterName)}</div>`
+              : ""
+          }
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- render the school logo from super admin branding in both the interactive and exported report card layouts
- show the uploaded headmaster signature (and fallback line) with an optional headmaster name caption on report cards
- align styling updates so signature images, placeholders, and captions print correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e482fe93ec8327b0cd440c92041254