### PR TITLE
Fix report card subject switching persistence

### DIFF
--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -1187,6 +1187,7 @@ export function TeacherDashboard({
   }, [selectedClass])
 
   const [marksData, setMarksData] = useState<MarksRecord[]>([])
+  const lastPersistedSelectionRef = useRef<string | null>(null)
   const suppressMarksRefreshRef = useRef(false)
 
   const loadRosterCandidates = useCallback(async () => {
@@ -2488,8 +2489,32 @@ export function TeacherDashboard({
   }, [loadAdditionalData])
 
   useEffect(() => {
+    const selectionKey = [
+      selectedClass || "",
+      selectedSubject || "",
+      normalizedTermLabel,
+      selectedSession,
+    ].join("::")
+
+    if (!selectedClass || !selectedSubject || marksData.length === 0) {
+      lastPersistedSelectionRef.current = selectionKey
+      return
+    }
+
+    if (lastPersistedSelectionRef.current !== selectionKey) {
+      lastPersistedSelectionRef.current = selectionKey
+      return
+    }
+
     persistAcademicMarksToStorage()
-  }, [persistAcademicMarksToStorage])
+  }, [
+    marksData,
+    normalizedTermLabel,
+    persistAcademicMarksToStorage,
+    selectedClass,
+    selectedSession,
+    selectedSubject,
+  ])
 
   useEffect(() => {
     setWorkflowRecords(getWorkflowRecords())


### PR DESCRIPTION
## Summary
- ensure subject changes in the teacher dashboard do not immediately persist marks for the new selection
- track the last persisted class/subject combination before auto-saving report card data

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e50bbd6a848327949bfac4c54ad029