### PR TITLE
Align headmaster signature in report card

### DIFF
--- a/components/enhanced-report-card.tsx
+++ b/components/enhanced-report-card.tsx
@@ -1136,7 +1136,7 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
               <span className="signature-label">Teacher&apos;s Signature:</span>
               <div className="signature-line" />
             </div>
-            <div className="signature-item">
+            <div className="signature-item headmaster-signature">
               <span className="signature-label">Headmaster&apos;s Signature:</span>
               {reportCardData.branding.signature ? (
                 <div className="signature-image">
@@ -1440,6 +1440,12 @@ export function EnhancedReportCard({ data }: { data?: RawReportCardData }) {
           gap: 12px;
           font-weight: 600;
           color: #27613d;
+        }
+
+        .signature-item.headmaster-signature {
+          margin-left: auto;
+          align-items: flex-end;
+          text-align: right;
         }
 
         .signature-label {


### PR DESCRIPTION
## Summary
- move the headmaster signature container to its own modifier class so it can sit on the right side of the signature row
- add styling that right aligns the headmaster signature block and its contents away from the teacher signature

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e59546a40483279aab29c6e515e0c2