### PR TITLE
Fix hydration-safe initialization and alert dialog refs

### DIFF
--- a/components/student-game-hub.tsx
+++ b/components/student-game-hub.tsx
@@ -241,9 +241,7 @@ const selectSentenceRounds = (): SentenceRound[] => shuffleArray(SENTENCE_ROUNDS
 
 export function StudentGameHub() {
   // Math Sprint state
-  const [mathProblems, setMathProblems] = useState<MathProblem[]>(() =>
-    Array.from({ length: MATH_ROUND_SIZE }, generateMathProblem),
-  )
+  const [mathProblems, setMathProblems] = useState<MathProblem[]>([])
   const [mathActive, setMathActive] = useState(false)
   const [mathAnswered, setMathAnswered] = useState(false)
   const [mathIndex, setMathIndex] = useState(0)
@@ -253,7 +251,7 @@ export function StudentGameHub() {
   const [mathCelebration, setMathCelebration] = useState(false)
 
   // Spelling Bee state
-  const [spellingWords, setSpellingWords] = useState<SpellingWord[]>(selectSpellingWords)
+  const [spellingWords, setSpellingWords] = useState<SpellingWord[]>([])
   const [spellingActive, setSpellingActive] = useState(false)
   const [spellingPaused, setSpellingPaused] = useState(false)
   const [spellingIndex, setSpellingIndex] = useState(0)
@@ -265,7 +263,7 @@ export function StudentGameHub() {
   const spellingInputRef = useRef<HTMLInputElement | null>(null)
 
   // Sentence scramble state
-  const [sentenceRounds, setSentenceRounds] = useState<SentenceRound[]>(selectSentenceRounds)
+  const [sentenceRounds, setSentenceRounds] = useState<SentenceRound[]>([])
   const [sentenceActive, setSentenceActive] = useState(false)
   const [sentencePaused, setSentencePaused] = useState(false)
   const [sentenceIndex, setSentenceIndex] = useState(0)
@@ -279,20 +277,47 @@ export function StudentGameHub() {
   const currentWord = spellingWords[spellingIndex] ?? null
   const currentSentence = sentenceRounds[sentenceIndex] ?? null
 
-  const mathProgress = useMemo(
-    () => ((mathIndex + (mathAnswered ? 1 : 0)) / mathProblems.length) * 100,
-    [mathIndex, mathAnswered, mathProblems.length],
-  )
+  useEffect(() => {
+    if (mathProblems.length === 0) {
+      setMathProblems(Array.from({ length: MATH_ROUND_SIZE }, generateMathProblem))
+    }
+  }, [mathProblems.length])
 
-  const spellingProgress = useMemo(
-    () => ((spellingIndex + (spellingFeedback === "correct" ? 1 : 0)) / spellingWords.length) * 100,
-    [spellingIndex, spellingFeedback, spellingWords.length],
-  )
+  useEffect(() => {
+    if (spellingWords.length === 0) {
+      setSpellingWords(selectSpellingWords())
+    }
+  }, [spellingWords.length])
 
-  const sentenceProgress = useMemo(
-    () => (sentenceAttempts.length / sentenceRounds.length) * 100,
-    [sentenceAttempts.length, sentenceRounds.length],
-  )
+  useEffect(() => {
+    if (sentenceRounds.length === 0) {
+      setSentenceRounds(selectSentenceRounds())
+    }
+  }, [sentenceRounds.length])
+
+  const mathProgress = useMemo(() => {
+    if (mathProblems.length === 0) {
+      return 0
+    }
+    return ((mathIndex + (mathAnswered ? 1 : 0)) / mathProblems.length) * 100
+  }, [mathIndex, mathAnswered, mathProblems.length])
+
+  const spellingProgress = useMemo(() => {
+    if (spellingWords.length === 0) {
+      return 0
+    }
+    return (
+      ((spellingIndex + (spellingFeedback === "correct" ? 1 : 0)) / spellingWords.length) *
+      100
+    )
+  }, [spellingIndex, spellingFeedback, spellingWords.length])
+
+  const sentenceProgress = useMemo(() => {
+    if (sentenceRounds.length === 0) {
+      return 0
+    }
+    return (sentenceAttempts.length / sentenceRounds.length) * 100
+  }, [sentenceAttempts.length, sentenceRounds.length])
 
   // Math Sprint logic
   useEffect(() => {

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -6,82 +6,82 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
 
-function AlertDialog({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
-}
+const AlertDialog = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Root>
+>(({ ...props }, ref) => (
+  <AlertDialogPrimitive.Root ref={ref} data-slot="alert-dialog" {...props} />
+))
+AlertDialog.displayName = AlertDialogPrimitive.Root.displayName
 
-function AlertDialogTrigger({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-  return (
-    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  )
-}
+const AlertDialogTrigger = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Trigger>
+>(({ ...props }, ref) => (
+  <AlertDialogPrimitive.Trigger
+    ref={ref}
+    data-slot="alert-dialog-trigger"
+    {...props}
+  />
+))
+AlertDialogTrigger.displayName = AlertDialogPrimitive.Trigger.displayName
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return (
-    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  )
-}
+const AlertDialogPortal = (
+  props: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Portal>,
+) => <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName
 
-function AlertDialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
-  return (
-    <AlertDialogPrimitive.Overlay
-      data-slot="alert-dialog-overlay"
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    ref={ref}
+    data-slot="alert-dialog-overlay"
+    className={cn(
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+      className,
+    )}
+    {...props}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      data-slot="alert-dialog-content"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
         className,
       )}
       {...props}
     />
-  )
-}
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
 
-function AlertDialogContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
-  return (
-    <AlertDialogPortal>
-      <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
-        className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
-          className,
-        )}
-        {...props}
-      />
-    </AlertDialogPortal>
-  )
-}
-
-function AlertDialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<'div'>) {
-  return (
+const AlertDialogHeader = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => (
     <div
+      ref={ref}
       data-slot="alert-dialog-header"
       className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
-}
+  ),
+)
+AlertDialogHeader.displayName = 'AlertDialogHeader'
 
-function AlertDialogFooter({
-  className,
-  ...props
-}: React.ComponentProps<'div'>) {
-  return (
+const AlertDialogFooter = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => (
     <div
+      ref={ref}
       data-slot="alert-dialog-footer"
       className={cn(
         'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
@@ -89,58 +89,59 @@ function AlertDialogFooter({
       )}
       {...props}
     />
-  )
-}
+  ),
+)
+AlertDialogFooter.displayName = 'AlertDialogFooter'
 
-function AlertDialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
-  return (
-    <AlertDialogPrimitive.Title
-      data-slot="alert-dialog-title"
-      className={cn('text-lg font-semibold', className)}
-      {...props}
-    />
-  )
-}
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    data-slot="alert-dialog-title"
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
 
-function AlertDialogDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
-  return (
-    <AlertDialogPrimitive.Description
-      data-slot="alert-dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
-      {...props}
-    />
-  )
-}
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    data-slot="alert-dialog-description"
+    className={cn('text-muted-foreground text-sm', className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName
 
-function AlertDialogAction({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
-  return (
-    <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
-      {...props}
-    />
-  )
-}
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
 
-function AlertDialogCancel({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
-  return (
-    <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: 'outline' }), className)}
-      {...props}
-    />
-  )
-}
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: 'outline' }), className)}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
 
 export {
   AlertDialog,


### PR DESCRIPTION
## Summary
- generate student game hub rounds client-side to prevent hydration mismatches and keep progress calculations safe when data is unavailable
- wrap alert dialog primitives with forwardRef and preserve data-slot attributes so Radix refs work during hydration

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e59cd8f5d88327a56181d80ac14930