### PR TITLE
Increase Math Racing rival speed

### DIFF
--- a/components/games/math-racing.tsx
+++ b/components/games/math-racing.tsx
@@ -156,7 +156,9 @@ export default function MathRacing() {
     questionStartRef.current = Date.now()
     const interval = setInterval(() => {
       setRivalProgress((previous) => {
-        const updated = clampProgress(previous + (3 + Math.random() * 4) / 10)
+        const baseIncrement = (3 + Math.random() * 4) / 10
+        const speedMultiplier = 5
+        const updated = clampProgress(previous + baseIncrement * speedMultiplier)
         if (updated >= 100) {
           stopRace("🏁 Rival championed the race. Try again!")
         }


### PR DESCRIPTION
## Summary
- accelerate the rival car in Math Racing by applying a 5x speed multiplier to its progress ticks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a7d5a1088327a68c1292ef83cbc0