### PR TITLE
Ensure teacher subject lists normalize existing subjects

### DIFF
--- a/app/api/teachers/context/route.ts
+++ b/app/api/teachers/context/route.ts
@@ -5,6 +5,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { getUserByIdFromDb } from "@/lib/database"
 import { logger } from "@/lib/logger"
 import { verifyToken } from "@/lib/security"
+import { normalizeSubjectList } from "@/lib/subject-utils"
 
 const normalizeRole = (value: unknown): string => {
   if (typeof value !== "string") {
@@ -21,27 +22,6 @@ const normalizeIdentifier = (value: unknown): string => {
 
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : ""
-}
-
-const normalizeSubjects = (value: unknown): string[] => {
-  if (!Array.isArray(value)) {
-    return []
-  }
-
-  const seen = new Set<string>()
-  for (const entry of value) {
-    if (typeof entry !== "string") {
-      continue
-    }
-
-    const trimmed = entry.trim()
-    if (trimmed.length === 0 || seen.has(trimmed)) {
-      continue
-    }
-    seen.add(trimmed)
-  }
-
-  return Array.from(seen)
 }
 
 export async function GET(request: NextRequest) {
@@ -99,7 +79,7 @@ export async function GET(request: NextRequest) {
       }
       seenClassKeys.add(key)
 
-      const subjects = normalizeSubjects((assignment as { subjects?: unknown }).subjects)
+      const subjects = normalizeSubjectList((assignment as { subjects?: unknown }).subjects)
       for (const subject of subjects) {
         subjectSet.add(subject)
       }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,7 @@ import type { RawReportCardData } from "@/lib/report-card-types"
 import { AutomaticPromotionSystem } from "@/components/automatic-promotion-system"
 import { getStudentReportCardData } from "@/lib/report-card-data"
 import { InternalMessaging, type MessagingParticipant } from "@/components/internal-messaging"
+import { normalizeSubjectList } from "@/lib/subject-utils"
 import { AdminApprovalDashboard } from "@/components/admin-approval-dashboard"
 import { safeStorage } from "@/lib/safe-storage"
 import { getBrandingFromStorage } from "@/lib/branding"
@@ -1334,18 +1335,7 @@ const buildTeacherAssignmentsFromUser = (
 
     const resolvedId = id || (name ? buildIdentifierFromName(name) : `class_${index}`)
     const resolvedName = name || id || `Class ${index + 1}`
-    const normalizedSubjects: string[] = []
-
-    if (Array.isArray(subjectsValue)) {
-      for (const subject of subjectsValue) {
-        if (typeof subject === "string") {
-          const trimmed = subject.trim()
-          if (trimmed.length > 0) {
-            normalizedSubjects.push(trimmed)
-          }
-        }
-      }
-    }
+    const normalizedSubjects = normalizeSubjectList(subjectsValue)
     const key = `${resolvedId.toLowerCase()}::${resolvedName.toLowerCase()}`
 
     if (classMap.has(key)) {
@@ -1509,11 +1499,7 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         payload.classes.forEach((entry, index) => {
           const rawId = typeof entry?.id === "string" ? entry.id.trim() : ""
           const rawName = typeof entry?.name === "string" ? entry.name.trim() : ""
-          const subjects = Array.isArray(entry?.subjects)
-            ? entry.subjects
-                .map((subject) => (typeof subject === "string" ? subject.trim() : ""))
-                .filter((subject) => subject.length > 0)
-            : []
+          const subjects = normalizeSubjectList(entry?.subjects)
           const id = rawId || rawName || `class_${index}`
           const name = rawName || rawId || id
 
@@ -1532,16 +1518,7 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         })
       }
 
-      if (Array.isArray(payload.subjects)) {
-        for (const subject of payload.subjects) {
-          if (typeof subject === "string") {
-            const trimmed = subject.trim()
-            if (trimmed.length > 0) {
-              subjectSet.add(trimmed)
-            }
-          }
-        }
-      }
+      normalizeSubjectList(payload.subjects).forEach((subject) => subjectSet.add(subject))
 
       const normalizedSubjects = Array.from(subjectSet)
 

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -11,6 +11,7 @@ import mysql, {
 import { safeStorage } from "./safe-storage"
 import { logger } from "./logger"
 import { deriveGradeFromScore } from "./grade-utils"
+import { normalizeSubjectList } from "./subject-utils"
 
 interface CollectionRecord {
   id: string
@@ -1699,9 +1700,7 @@ function buildTeacherAssignmentAugmentorFromCollections(
 
       seenClassIds.add(classRecord.id)
 
-      const classSubjects = Array.isArray(classRecord.subjects)
-        ? classRecord.subjects.filter((subject): subject is string => typeof subject === "string" && subject.trim().length > 0)
-        : []
+      const classSubjects = normalizeSubjectList(classRecord.subjects)
 
       for (const subject of classSubjects) {
         addSubject(subject)
@@ -1738,9 +1737,7 @@ function buildTeacherAssignmentAugmentorFromCollections(
 
         seenClassIds.add(classRecord.id)
 
-        const classSubjects = Array.isArray(classRecord.subjects)
-          ? classRecord.subjects.filter((subject): subject is string => typeof subject === "string" && subject.trim().length > 0)
-          : []
+        const classSubjects = normalizeSubjectList(classRecord.subjects)
 
         for (const subject of classSubjects) {
           addSubject(subject)
@@ -1850,9 +1847,7 @@ function resolveTeacherClassesForIdentifiers(identifiers: string[], classes: Cla
       throw new Error(`Class not found for identifier: ${identifier}`)
     }
 
-    const classSubjects = Array.isArray(classRecord.subjects)
-      ? classRecord.subjects.filter((subject): subject is string => typeof subject === "string" && subject.trim().length > 0)
-      : []
+    const classSubjects = normalizeSubjectList(classRecord.subjects)
 
     if (classSubjects.length === 0) {
       throw new Error(`Cannot assign teacher to ${classRecord.name} because it has no subjects`)

--- a/lib/subject-utils.ts
+++ b/lib/subject-utils.ts
@@ -1,0 +1,90 @@
+import { logger } from "./logger"
+
+const SUBJECT_NAME_KEYS = ["name", "subject", "subjectName", "title", "label", "text", "value"] as const
+
+const MAX_RECURSION_DEPTH = 3
+
+type SubjectLikeRecord = Record<string, unknown>
+
+function isPlainObject(value: unknown): value is SubjectLikeRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function extractFromRecord(record: SubjectLikeRecord, depth: number): string | null {
+  for (const key of SUBJECT_NAME_KEYS) {
+    const candidate = record[key]
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim()
+      if (trimmed.length > 0) {
+        return trimmed
+      }
+      continue
+    }
+
+    if (isPlainObject(candidate) && depth < MAX_RECURSION_DEPTH) {
+      const nested = extractFromRecord(candidate, depth + 1)
+      if (nested) {
+        return nested
+      }
+    }
+  }
+
+  if (depth < MAX_RECURSION_DEPTH) {
+    for (const value of Object.values(record)) {
+      if (typeof value === "string") {
+        const trimmed = value.trim()
+        if (trimmed.length > 0) {
+          return trimmed
+        }
+        continue
+      }
+
+      if (isPlainObject(value)) {
+        const nested = extractFromRecord(value, depth + 1)
+        if (nested) {
+          return nested
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+export function extractSubjectName(entry: unknown): string | null {
+  if (typeof entry === "string") {
+    const trimmed = entry.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  if (isPlainObject(entry)) {
+    return extractFromRecord(entry, 0)
+  }
+
+  return null
+}
+
+export function normalizeSubjectList(value: unknown): string[] {
+  const seen = new Set<string>()
+
+  const push = (entry: unknown) => {
+    const subjectName = extractSubjectName(entry)
+    if (subjectName && !seen.has(subjectName)) {
+      seen.add(subjectName)
+    }
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(push)
+  } else if (value !== undefined && value !== null) {
+    push(value)
+  }
+
+  return Array.from(seen)
+}
+
+export function logSubjectNormalizationWarning(context: string, value: unknown) {
+  if (process.env.NODE_ENV === "development") {
+    logger.warn(`Unable to normalize subject entry for ${context}`, { value })
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper that extracts subject names from strings or object payloads
- use the helper when building teacher assignment context data and client-side state
- normalize stored class subjects inside the database helper so mark entry options stay in sync

## Testing
- npm run lint *(fails: pre-existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c03e194c832787ea24f540dbfa5a