### PR TITLE
Ensure report cards display stored student passports

### DIFF
--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -105,6 +105,7 @@ import {
   markAssignmentReminderSent,
   shouldSendAssignmentReminder,
 } from "@/lib/assignment-reminders"
+import { resolveStudentPassportFromCache } from "@/lib/student-passport"
 
 type BrowserRuntime = typeof globalThis & Partial<Window>
 
@@ -1481,6 +1482,15 @@ export function TeacherDashboard({
         grade: summaryGrade,
       }
 
+      const { passportUrl, photoUrl } = resolveStudentPassportFromCache(
+        {
+          id: String(student.studentId),
+          admissionNumber: aggregatedRaw?.student?.admissionNumber ?? `VEA/${student.studentId}`,
+          name: aggregatedRaw?.student?.name ?? student.studentName,
+        },
+        aggregatedRaw?.student ?? null,
+      )
+
       const basePreview: RawReportCardData = {
         student: {
           id: String(student.studentId),
@@ -1491,6 +1501,8 @@ export function TeacherDashboard({
           session: selectedSession,
           numberInClass: additionalData.termInfo.numberInClass,
           status: additionalData.studentStatus[student.studentId],
+          passportUrl,
+          photoUrl,
         },
         subjects: [
           {

--- a/lib/report-card-data.ts
+++ b/lib/report-card-data.ts
@@ -4,6 +4,7 @@ import type { RawReportCardData, StoredStudentMarkRecord, StoredSubjectRecord } 
 import { safeStorage } from "./safe-storage"
 import { logger } from "./logger"
 import { normalizeTermLabel } from "./report-card-access"
+import { resolveStudentPassportFromCache } from "./student-passport"
 import {
   AFFECTIVE_TRAITS,
   PSYCHOMOTOR_SKILLS,
@@ -280,6 +281,15 @@ export const buildRawReportCardFromStoredRecord = (
     numberOfStudents: record.numberInClass,
   }
 
+  const { passportUrl, photoUrl } = resolveStudentPassportFromCache(
+    {
+      id: record.studentId,
+      admissionNumber: record.studentId,
+      name: record.studentName,
+    },
+    null,
+  )
+
   return {
     student: {
       id: record.studentId,
@@ -290,6 +300,8 @@ export const buildRawReportCardFromStoredRecord = (
       session: record.session,
       numberInClass: record.numberInClass,
       status: record.status,
+      passportUrl,
+      photoUrl,
     },
     subjects: normalizedSubjects,
     summary,
@@ -427,6 +439,15 @@ export const getStudentReportCardData = (
   const average = totalObtainable > 0 ? Math.round((totalObtained / totalObtainable) * 100) : 0
   const position = average >= 80 ? "1st" : average >= 70 ? "2nd" : average >= 60 ? "3rd" : "4th"
 
+  const { passportUrl, photoUrl } = resolveStudentPassportFromCache(
+    {
+      id: studentId,
+      admissionNumber: `VEA/${studentId}/2024`,
+      name: studentData.studentName,
+    },
+    null,
+  )
+
   return {
     student: {
       id: studentId,
@@ -435,6 +456,8 @@ export const getStudentReportCardData = (
       class: studentData.class,
       term: normalizedTerm,
       session,
+      passportUrl,
+      photoUrl,
     },
     subjects,
     summary: {

--- a/lib/student-passport.ts
+++ b/lib/student-passport.ts
@@ -1,0 +1,193 @@
+import { safeStorage } from "./safe-storage"
+import { logger } from "./logger"
+
+interface StudentIdentifiers {
+  id?: string | null
+  admissionNumber?: string | null
+  name?: string | null
+}
+
+const normalizeTrimmedString = (value: unknown): string | null => {
+  if (typeof value === "string" || typeof value === "number") {
+    const trimmed = String(value).trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  return null
+}
+
+const normalizeComparisonToken = (value: unknown): string | null => {
+  const trimmed = normalizeTrimmedString(value)
+  return trimmed ? trimmed.replace(/\s+/g, "").toLowerCase() : null
+}
+
+const normalizeNameToken = (value: unknown): string | null => {
+  const trimmed = normalizeTrimmedString(value)
+  return trimmed ? trimmed.toLowerCase() : null
+}
+
+const extractStudentFromMetadata = (metadata: unknown): Record<string, unknown> | null => {
+  if (!metadata || typeof metadata !== "object") {
+    return null
+  }
+
+  const container = metadata as Record<string, unknown>
+  const candidate =
+    container.enhancedReportCard ??
+    container.enhancedReport ??
+    container.rawReportCard ??
+    container.reportCard ??
+    container.preview ??
+    null
+
+  if (candidate && typeof candidate === "object") {
+    const candidateRecord = candidate as Record<string, unknown>
+    const student = candidateRecord.student
+    if (student && typeof student === "object") {
+      return student as Record<string, unknown>
+    }
+  }
+
+  return null
+}
+
+const parseStudentsCache = (): Record<string, unknown>[] => {
+  const raw = safeStorage.getItem("students")
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed.filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === "object"))
+  } catch (error) {
+    logger.warn("Unable to parse cached students for passport lookup", { error })
+    return []
+  }
+}
+
+const parseReportCardStudents = (): Record<string, unknown>[] => {
+  const raw = safeStorage.getItem("reportCards")
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    const results: Record<string, unknown>[] = []
+
+    parsed.forEach((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return
+      }
+
+      const record = entry as Record<string, unknown>
+      const metadataStudent = extractStudentFromMetadata(record.metadata)
+
+      if (metadataStudent) {
+        results.push({
+          ...metadataStudent,
+          id: metadataStudent["id"] ?? record["studentId"],
+          admissionNumber: metadataStudent["admissionNumber"] ?? record["studentId"],
+          name: metadataStudent["name"] ?? record["studentName"],
+        })
+      }
+
+      results.push({
+        id: record["studentId"],
+        admissionNumber: record["studentId"],
+        name: record["studentName"],
+        passportUrl: record["passportUrl"],
+        photoUrl: record["photoUrl"],
+      })
+    })
+
+    return results
+  } catch (error) {
+    logger.warn("Unable to parse cached report cards for passport lookup", { error })
+    return []
+  }
+}
+
+const collectStudentCandidates = (): Record<string, unknown>[] => {
+  return [...parseStudentsCache(), ...parseReportCardStudents()]
+}
+
+const extractPassportFromRecord = (record: Record<string, unknown>): string | null => {
+  return (
+    normalizeTrimmedString(record["passportUrl"]) ??
+    normalizeTrimmedString(record["photoUrl"]) ??
+    normalizeTrimmedString(record["imageUrl"]) ??
+    normalizeTrimmedString(record["avatarUrl"])
+  )
+}
+
+const extractPhotoFromRecord = (record: Record<string, unknown>): string | null => {
+  return (
+    normalizeTrimmedString(record["photoUrl"]) ??
+    normalizeTrimmedString(record["passportUrl"]) ??
+    normalizeTrimmedString(record["imageUrl"]) ??
+    normalizeTrimmedString(record["avatarUrl"])
+  )
+}
+
+export const resolveStudentPassportFromCache = (
+  identifiers: StudentIdentifiers,
+  fallback?: Record<string, unknown> | null,
+): { passportUrl: string | null; photoUrl: string | null } => {
+  const normalizedId = normalizeComparisonToken(identifiers.id)
+  const normalizedAdmission = normalizeComparisonToken(identifiers.admissionNumber)
+  const normalizedName = normalizeNameToken(identifiers.name)
+
+  let resolvedPassport: string | null = null
+  let resolvedPhoto: string | null = null
+
+  if (fallback && typeof fallback === "object") {
+    resolvedPassport = extractPassportFromRecord(fallback)
+    resolvedPhoto = extractPhotoFromRecord(fallback)
+  }
+
+  const candidates = collectStudentCandidates()
+
+  for (const candidate of candidates) {
+    const candidateId = normalizeComparisonToken(candidate["id"] ?? candidate["studentId"])
+    const candidateAdmission = normalizeComparisonToken(
+      candidate["admissionNumber"] ?? candidate["admission"] ?? candidate["admissionNo"],
+    )
+    const candidateName = normalizeNameToken(candidate["name"] ?? candidate["studentName"])
+
+    const matches =
+      (normalizedId && candidateId === normalizedId) ||
+      (normalizedAdmission && candidateAdmission === normalizedAdmission) ||
+      (normalizedName && candidateName === normalizedName)
+
+    if (!matches) {
+      continue
+    }
+
+    if (!resolvedPassport) {
+      resolvedPassport = extractPassportFromRecord(candidate)
+    }
+
+    if (!resolvedPhoto) {
+      resolvedPhoto = extractPhotoFromRecord(candidate)
+    }
+
+    if (resolvedPassport && resolvedPhoto) {
+      break
+    }
+  }
+
+  return {
+    passportUrl: resolvedPassport ?? null,
+    photoUrl: resolvedPhoto ?? resolvedPassport ?? null,
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve cached passport URLs for students
- populate report card payloads and teacher previews with the resolved passport/photo values
- ensure generated report cards consistently surface student passport images

## Testing
- npm run lint *(fails: existing lint violations across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c087588883279266b9cd11edfdad