### PR TITLE
Fix subject selection flow on teacher marks tab

### DIFF
--- a/components/teacher-dashboard.tsx
+++ b/components/teacher-dashboard.tsx
@@ -858,6 +858,20 @@ export function TeacherDashboard({
     [normalizeClassName, selectedClass, teacherClasses],
   )
 
+  const handleSelectSubject = useCallback(
+    (value: string) => {
+      const normalizedValue = typeof value === "string" ? value.trim() : ""
+
+      if (normalizedValue === selectedSubject.trim()) {
+        return
+      }
+
+      setMarksData([])
+      setSelectedSubject(normalizedValue)
+    },
+    [selectedSubject, setMarksData],
+  )
+
   const subjectsForSelectedClass = useMemo(() => {
     const subjectSet = new Set<string>()
     const normalizedName = normalizeClassName(selectedClass)
@@ -4601,8 +4615,12 @@ export function TeacherDashboard({
                     <Label>Subject</Label>
                     <Select
                       value={selectedSubject}
-                      onValueChange={setSelectedSubject}
-                      disabled={isContextLoading || isClassSubjectsLoading}
+                      onValueChange={handleSelectSubject}
+                      disabled={
+                        !selectedClass ||
+                        isContextLoading ||
+                        (isClassSubjectsLoading && availableSubjects.length === 0)
+                      }
                     >
                       <SelectTrigger className="w-full">
                         <SelectValue placeholder="Select Subject" />


### PR DESCRIPTION
## Summary
- add a dedicated subject selection handler that normalizes the teacher's choice and clears stale mark data before loading
- relax the subject dropdown disabled state so teachers can open it once a class is selected, even if subjects are still loading

## Testing
- npx eslint components/teacher-dashboard.tsx *(fails: existing lint violations in teacher-dashboard.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e63b8d47b8832796275edeeb2534fb