### PR TITLE
feat: add teacher subject switching workflow

### DIFF
--- a/app/api/teachers/[teacherId]/subjects/route.ts
+++ b/app/api/teachers/[teacherId]/subjects/route.ts
@@ -1,0 +1,111 @@
+export const runtime = "nodejs"
+
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getUserByIdFromDb } from "@/lib/database"
+import { summarizeTeacherAssignments } from "@/lib/teacher-assignment"
+import { logger } from "@/lib/logger"
+import { verifyToken } from "@/lib/security"
+
+const normalizeRole = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return ""
+  }
+
+  return value.trim().toLowerCase().replace(/[\s-]+/g, "_")
+}
+
+const normalizeIdentifier = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return ""
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : ""
+}
+
+const isPrivilegedRole = (role: string) => role === "super_admin" || role === "admin"
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { teacherId?: string } },
+) {
+  try {
+    const authHeader = request.headers.get("authorization")
+    if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const token = authHeader.slice(7)
+    let decoded: any
+    try {
+      decoded = verifyToken(token)
+    } catch (error) {
+      logger.warn("Rejected teacher subject lookup due to invalid token", {
+        error: error instanceof Error ? error.message : error,
+      })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const requesterId = normalizeIdentifier(decoded?.userId)
+    const requesterRole = normalizeRole(decoded?.role)
+    if (!requesterId || !requesterRole) {
+      logger.warn("Rejected teacher subject lookup because token payload was incomplete")
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const requestedTeacherId = normalizeIdentifier(context.params?.teacherId)
+    if (!requestedTeacherId) {
+      return NextResponse.json({ error: "Teacher identifier is required" }, { status: 400 })
+    }
+
+    if (requesterRole === "teacher" && requesterId !== requestedTeacherId) {
+      logger.warn("Teacher attempted to access another teacher's subject assignments", {
+        requesterId,
+        requestedTeacherId,
+      })
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    if (requesterRole !== "teacher" && !isPrivilegedRole(requesterRole)) {
+      logger.warn("Rejected teacher subject lookup for unsupported role", {
+        requesterId,
+        role: requesterRole,
+      })
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const teacherRecord = await getUserByIdFromDb(requestedTeacherId)
+    if (!teacherRecord || normalizeRole(teacherRecord.role) !== "teacher") {
+      logger.warn("Teacher subject lookup failed because teacher record was not found", {
+        requestedTeacherId,
+      })
+      return NextResponse.json({ error: "Teacher not found" }, { status: 404 })
+    }
+
+    const { classes, subjects } = summarizeTeacherAssignments(teacherRecord)
+
+    logger.info("Teacher subject assignments resolved", {
+      teacherId: teacherRecord.id,
+      subjectCount: subjects.length,
+      classCount: classes.length,
+    })
+
+    return NextResponse.json({
+      teacher: {
+        id: teacherRecord.id,
+        name: teacherRecord.name,
+        email: teacherRecord.email,
+      },
+      subjects,
+      classes,
+      message:
+        subjects.length === 0
+          ? "No subjects have been assigned to this teacher yet. Please contact the administrator."
+          : undefined,
+    })
+  } catch (error) {
+    logger.error("Failed to resolve teacher subject assignments", { error })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/lib/teacher-assignment.ts
+++ b/lib/teacher-assignment.ts
@@ -1,0 +1,195 @@
+import { normalizeSubjectList } from "./subject-utils"
+import type { StoredUser, TeacherAssignmentSummary } from "./database"
+
+export type NormalizedTeacherClassAssignment = {
+  id: string
+  name: string
+  subjects: string[]
+}
+
+export type TeacherAssignmentSnapshot = {
+  classes: NormalizedTeacherClassAssignment[]
+  subjects: string[]
+}
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return ""
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : ""
+}
+
+const buildIdentifierFromName = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+const registerClassAssignment = (
+  registry: NormalizedTeacherClassAssignment[],
+  subjectSet: Set<string>,
+  indexById: Map<string, number>,
+  indexByName: Map<string, number>,
+  idValue: unknown,
+  nameValue?: unknown,
+  subjectsValue?: unknown,
+  fallbackIndex?: number,
+) => {
+  const rawId = normalizeString(idValue)
+  const rawName = normalizeString(nameValue)
+  const normalizedSubjects = normalizeSubjectList(subjectsValue)
+
+  normalizedSubjects.forEach((subject) => subjectSet.add(subject))
+
+  if (!rawId && !rawName && normalizedSubjects.length === 0) {
+    return
+  }
+
+  const fallbackPosition = typeof fallbackIndex === "number" ? fallbackIndex : registry.length
+  const resolvedId = rawId || (rawName ? buildIdentifierFromName(rawName) : `class_${fallbackPosition + 1}`)
+  const resolvedName = rawName || rawId || `Class ${fallbackPosition + 1}`
+
+  const idToken = resolvedId.trim().toLowerCase()
+  const nameToken = resolvedName.trim().toLowerCase()
+
+  const existingIndex =
+    (idToken && indexById.has(idToken) ? indexById.get(idToken) : undefined) ??
+    (nameToken && indexByName.has(nameToken) ? indexByName.get(nameToken) : undefined) ??
+    -1
+
+  if (existingIndex !== undefined && existingIndex >= 0) {
+    const existing = registry[existingIndex]
+    const mergedSubjects = new Set([...existing.subjects, ...normalizedSubjects])
+    registry[existingIndex] = {
+      id: existing.id || resolvedId,
+      name: existing.name || resolvedName,
+      subjects: Array.from(mergedSubjects),
+    }
+
+    if (idToken) {
+      indexById.set(idToken, existingIndex)
+    }
+
+    if (nameToken) {
+      indexByName.set(nameToken, existingIndex)
+    }
+
+    return
+  }
+
+  const insertionIndex = registry.length
+  registry.push({
+    id: resolvedId,
+    name: resolvedName,
+    subjects: normalizedSubjects,
+  })
+
+  if (idToken) {
+    indexById.set(idToken, insertionIndex)
+  }
+
+  if (nameToken) {
+    indexByName.set(nameToken, insertionIndex)
+  }
+}
+
+export const summarizeTeacherAssignments = (
+  teacher: Partial<StoredUser> & Record<string, unknown>,
+): TeacherAssignmentSnapshot => {
+  const registry: NormalizedTeacherClassAssignment[] = []
+  const indexById = new Map<string, number>()
+  const indexByName = new Map<string, number>()
+  const subjectSet = new Set<string>()
+
+  const teachingAssignments = Array.isArray(teacher.teachingAssignments)
+    ? (teacher.teachingAssignments as TeacherAssignmentSummary[])
+    : []
+
+  teachingAssignments.forEach((assignment, index) => {
+    registerClassAssignment(
+      registry,
+      subjectSet,
+      indexById,
+      indexByName,
+      (assignment as TeacherAssignmentSummary)?.classId,
+      (assignment as TeacherAssignmentSummary)?.className,
+      (assignment as TeacherAssignmentSummary)?.subjects,
+      index,
+    )
+  })
+
+  const assignedSummaries = Array.isArray((teacher as { assignedClasses?: unknown }).assignedClasses)
+    ? ((teacher as { assignedClasses?: Array<{ id?: unknown; name?: unknown; subjects?: unknown }> }).assignedClasses ?? [])
+    : []
+
+  assignedSummaries.forEach((entry, index) => {
+    registerClassAssignment(
+      registry,
+      subjectSet,
+      indexById,
+      indexByName,
+      entry?.id,
+      entry?.name,
+      entry?.subjects,
+      teachingAssignments.length + index,
+    )
+  })
+
+  const fallbackAssignedIds = Array.isArray((teacher as { assignedClassIds?: unknown }).assignedClassIds)
+    ? ((teacher as { assignedClassIds?: unknown[] }).assignedClassIds ?? [])
+    : []
+
+  fallbackAssignedIds.forEach((identifier, index) => {
+    registerClassAssignment(
+      registry,
+      subjectSet,
+      indexById,
+      indexByName,
+      identifier,
+      undefined,
+      undefined,
+      teachingAssignments.length + assignedSummaries.length + index,
+    )
+  })
+
+  const fallbackAssignedNames = Array.isArray((teacher as { assignedClassNames?: unknown }).assignedClassNames)
+    ? ((teacher as { assignedClassNames?: unknown[] }).assignedClassNames ?? [])
+    : []
+
+  fallbackAssignedNames.forEach((name, index) => {
+    registerClassAssignment(
+      registry,
+      subjectSet,
+      indexById,
+      indexByName,
+      undefined,
+      name,
+      undefined,
+      teachingAssignments.length + assignedSummaries.length + fallbackAssignedIds.length + index,
+    )
+  })
+
+  registerClassAssignment(
+    registry,
+    subjectSet,
+    indexById,
+    indexByName,
+    (teacher as { classId?: unknown }).classId,
+    (teacher as { className?: unknown }).className,
+    teacher.subjects,
+    teachingAssignments.length +
+      assignedSummaries.length +
+      fallbackAssignedIds.length +
+      fallbackAssignedNames.length,
+  )
+
+  normalizeSubjectList(teacher.subjects).forEach((subject) => subjectSet.add(subject))
+
+  return {
+    classes: registry,
+    subjects: Array.from(subjectSet),
+  }
+}


### PR DESCRIPTION
## Summary
- add shared helpers to normalize teacher assignment data
- expose an endpoint for retrieving teacher subject assignments and reuse the helper in the teacher context API
- refresh the teacher dashboard to load assigned subjects dynamically, tighten the available subject list, and surface clearer status messaging when no subjects are assigned

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations outside the touched scope)*

------
https://chatgpt.com/codex/tasks/task_e_68e65afebc008327935ed907f73e0389